### PR TITLE
Use debounce instead of throttle to send less queries to /suggestions

### DIFF
--- a/client/components/search.js
+++ b/client/components/search.js
@@ -1,6 +1,6 @@
 import { selectDomain } from '../actions/index';
 import { connect } from 'react-redux';
-import throttle from 'lodash/throttle';
+import debounce from 'lodash/debounce';
 import React from 'react';
 import WPCOM from 'wpcom';
 import { Link } from 'react-router';
@@ -29,7 +29,7 @@ const Search = React.createClass( {
 	},
 
 	componentDidMount() {
-		this.debouncedGetDomainSuggestions = throttle( this.getDomainSuggestions, 500 );
+		this.debouncedGetDomainSuggestions = debounce( this.getDomainSuggestions, 500 );
 	},
 
 	onChange( event ) {


### PR DESCRIPTION
Suggestions calls are expensive, we can't do millions of them. With throttle, we do far too many queries because it does at least one request every 500ms. Debounce will only send one after 500ms with no change.
