### PR TITLE
Generate a separate build for the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "test": "NODE_PATH=app jest",
     "build": "node_modules/.bin/webpack --config webpack.config.js --progress --colors",
+    "build:client": "node_modules/.bin/webpack --config webpack.config.js --progress --colors",
+    "build:server": "node_modules/.bin/webpack --config webpack.server.config.js --verbose --progress --colors",
+    "build": "npm run build:client && npm run build:server",
     "lint": "eslint --max-warnings 0 client server",
-    "start": "npm install && node server",
-    "quickstart": "node server",
+    "start": "npm install && npm run build && node build/server.bundle",
+    "qs": "npm run build && node build/server.bundle",
     "postinstall": "npm run-script build"
   },
   "repository": {

--- a/server/index.js
+++ b/server/index.js
@@ -17,23 +17,10 @@ isDevelopment = 'production' !== process.env.NODE_ENV;
 if ( isDevelopment ) {
 	app.set( 'backend-port', app.get( 'port' ) + 1 );
 
-	config = require( '../webpack.config' );
-	config.entry.bundle.unshift( 'webpack/hot/only-dev-server' );
-	config.entry.bundle.unshift( 'webpack-dev-server/client?/' );
-	config.plugins.push( new webpack.HotModuleReplacementPlugin() );
-
-	config.module.loaders.unshift( {
-		test: /\.jsx?$/,
-		loader: 'react-hot',
-		include: [
-			path.join( __dirname, '../app' ),
-			path.join( __dirname, '../client' ),
-			path.join( __dirname, '../lib' )
-		]
-	} );
-
 	WebpackDevServer = require( 'webpack-dev-server' );
+	config = require( '../webpack.config' );
 	compiler = webpack( config );
+
 	devServer = new WebpackDevServer( compiler, {
 		publicPath: config.output.publicPath,
 		hot: true,

--- a/server/views/index.html
+++ b/server/views/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<script src="build/bundle.js" async></script>
+		<script src="build/client.bundle.js" async></script>
 	</head>
 	<body style="margin: 0; padding: 0;">
 		<div id="content"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,29 +1,27 @@
-// External dependencies
-var path = require( 'path' ),
-	webpack = require( 'webpack' );
+/**
+ * External dependencies
+ */
+var webpack = require( 'webpack' ),
+	path = require( 'path' );
 
 module.exports = {
-	entry: {
-		'bundle': [
-			path.join( __dirname, 'client' )
-		]
-	},
+	entry: [
+		'webpack/hot/only-dev-server',
+		'webpack-dev-server/client?/',
+		path.join( __dirname, 'client' )
+	],
 	output: {
-		path: path.join( __dirname, 'build' ),
+		path: path.resolve( __dirname, 'build' ),
 		publicPath: '/build/',
-		filename: '[name].js',
+		filename: 'client.bundle.js',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]'
 	},
 	module: {
 		loaders: [
 			{
 				test: /\.jsx?$/,
-				loader: 'babel-loader',
-				include: [
-					path.join( __dirname, 'app' ),
-					path.join( __dirname, 'client' ),
-					path.join( __dirname, 'lib' )
-				]
+				loaders: [ 'react-hot', 'babel-loader' ],
+				exclude: /node_modules/
 			},
 			{
 				test: /\.json$/,
@@ -33,9 +31,10 @@ module.exports = {
 				test: /\.scss$/,
 				loader: 'style!css!sass?sourceMap'
 			}
-		]
+		],
 	},
 	plugins: [
+		new webpack.HotModuleReplacementPlugin(),
 		new webpack.DefinePlugin( {
 			'process.env': {
 				WPCOM_API_KEY: '"' + process.env.WPCOM_API_KEY + '"'
@@ -63,5 +62,5 @@ module.exports = {
 		__filename: 'mock',
 		__dirname: 'mock',
 		fs: 'empty'
-	}
+	},
 };

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -1,0 +1,47 @@
+var fs = require( 'fs' ),
+	path = require( 'path' );
+
+function getExternals() {
+	var externals = {};
+
+	fs.readdirSync( path.resolve( __dirname, 'node_modules' ) )
+		.filter( function( module ) {
+			return [ '.bin' ].indexOf( module ) === -1;
+		} )
+		.forEach( function( module ) {
+			externals[ module ] = 'commonjs ' + module;
+		} );
+
+	return externals;
+}
+
+module.exports = {
+	entry: path.resolve( __dirname, 'server/index.js' ),
+
+	output: {
+		path: path.resolve( __dirname, 'build' ),
+		publicPath: '/build/',
+		filename: 'server.bundle.js'
+	},
+
+	target: 'node',
+
+	externals: getExternals(),
+
+	node: {
+		__filename: true,
+		__dirname: true
+	},
+
+	module: {
+		loaders: [ {
+			test: /\.jsx?$/,
+			loader: 'babel-loader',
+			include: [
+				path.join( __dirname, 'app' ),
+				path.join( __dirname, 'lib' ),
+				path.join( __dirname, 'server' )
+			]
+		} ]
+	}
+};


### PR DESCRIPTION
Our server app runs with Node, which doesn't interpret ES6 without production-unsafe flags enabled. This commit updates our build process to create a separate build for our server application.

**Testing**
There should be no changes to the way the behavior of the application.
- Run `npm start`
- Visit `/search`.
- Assert that you see "Enter a domain".
- Assert that hot reloading works properly. You can do this by open `app/components/search/index.js`, editing "Enter a domain", and asserting that your edit is updated in the browser without a refresh.
- [x] Product review
- [x] Code review
