### PR TITLE
Enable source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,8 @@ module.exports = {
 		port: 1337,
 		historyApiFallback: true
 	},
+	devtool:
+		'eval',
 	entry: [
 		'webpack/hot/only-dev-server',
 		'webpack-dev-server/client?/',


### PR DESCRIPTION
This pull request enables [source maps](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map) to ease debugging.
#### Testing instructions
1. Run `git checkout add/source-maps` and start your server
2. Open the [`Search` page](http://localhost:1337/)
3. Add `debugger;` above [this line](https://github.com/Automattic/delphin/blob/decea95662361f79c61aca44fb1d2695fd307c5d/app/components/ui/search/suggestion.js#L7)
4. Search for a domain and click a suggestion
5. Check that the browser console shows up and stops in `suggestion.js`
#### Reviews
- [x] Code
