### PR TITLE
Use basic auth in production

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -1,5 +1,5 @@
 const config = {
-	env: process.env.NODE_ENV,
+	env: process.env.NODE_ENV || 'development',
 	i18n_default_locale_slug: 'en'
 };
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^0.23.1",
     "debug": "^2.2.0",
     "express": "^4.13.4",
+    "http-auth": "^2.3.1",
     "inherits": "^2.0.1",
     "jed": "1.0.2",
     "jest-cli": "^11.0.0",

--- a/server/credentials
+++ b/server/credentials
@@ -1,0 +1,1 @@
+delphin:thanksforallthefish


### PR DESCRIPTION
This PR updates the server module to require basic HTTP authentication in production. The purpose of this is to keep the build we have running on Heroku private.

The username/password combo is simple and included in the repo itself, because:
- We will want to share these internally.
- This will be removed before Delphin is launched, and before this repo is public.

**Testing**
- Run `npm run build && npm run prod`
- Visit http://delphin.localhost:1337
- Assert that you see a dialog asking for credentials.
- Enter `delphin` and `thanksforallthefish` as the username/password and continue.
- Assert Delphin loads in the browser properly.
- [x] Code review
- [x] Product review
