### PR TITLE
i18n: Add a script to export i18n strings from delphin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ node_modules
 # Secrets
 server/secrets.json
 
+# Translations
+delphin_i18n_strings.php

--- a/bin/get-i18n
+++ b/bin/get-i18n
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * External dependencies/
+ */
+var fs = require( 'fs' ),
+	path = require( 'path' ),
+	program = require( 'commander' );
+
+/**
+ * Internal dependencies/
+ */
+var i18n = require( '../lib/glotpress/get-i18n-strings.js' );
+
+/**
+ * Internal variables/
+ */
+var outputFile, arrayName, inputFiles, inputPaths;
+
+function collect( val, memo ) {
+	memo.push( val );
+	return memo;
+}
+
+program
+	.version( '0.0.1' )
+	.option( '-o, --output-file <file>', 'output file for WP-style translation functions' )
+	.option( '-a, --array-name <name>', 'name of variable in generated php file that contains array of method calls' )
+	.option( '-i, --input-file <filename>', 'files in which to search for translation methods', collect, [] )
+	.usage( 'outputFile arrayName inputFile [inputFile ...]' )
+	.on( '--help', function() {
+		console.log( '  Examples' );
+		console.log( '\n    $ get-i18n ./outputFile.txt calypso_i18n_strings ./inputFile.js ./inputFile2.js' );
+		console.log( '    $ get-i18n -i ./inputFile.js -i ./inputFile2.js -o ./outputFile.txt -a calypso_i18n_strings' );
+		console.log( '\n  Sample Output' );
+		console.log( '\n    <?php' );
+		console.log( '    $calypso_i18n_strings = array (' );
+		console.log( '      __( \' Example1 \' ),' );
+		console.log( '      __( \' Example2 \' ),' );
+		console.log( '    );' );
+		console.log( '' );
+	} )
+	.parse( process.argv );
+
+outputFile = program.outputFile || program.args[0];
+arrayName = program.arrayName || program.args[1];
+inputFiles = ( program.inputFile.length ) ? program.inputFile : program.args.slice( 2 );
+
+if ( inputFiles.length === 0 ) {
+	console.log( 'Error: You must enter the input file. Run `get-i18n -h` for examples.' );
+	throw new Error( 'Error: You must enter the input file. Run `get-i18n -h` for examples.' );
+}
+if ( ! outputFile ) {
+	console.log( 'Error: You must enter the output file. Run `get-i18n -h` for examples.' );
+	throw new Error( 'Error: You must enter the output file. Run `get-i18n -h` for examples.' );
+}
+if ( ! arrayName ) {
+	console.log( 'Error: You must enter the php variable name for the array of translation calls.' );
+	throw new Error( 'Error: You must enter the php variable name for the array of translation calls.' );
+}
+
+outputFile = path.resolve( process.env.PWD, outputFile );
+
+// files relative to terminal location
+inputPaths = inputFiles.map( function( fileName ) {
+	return path.resolve( process.env.PWD, fileName );
+} );
+
+inputPaths.forEach( function( inputFile ) {
+	if ( ! fs.existsSync( inputFile ) ) {
+		console.log( 'Error: inputFile, `' + inputFile + '`, does not exist' );
+	}
+} );
+
+i18n( outputFile, arrayName, inputPaths );

--- a/lib/glotpress/get-i18n-strings.js
+++ b/lib/glotpress/get-i18n-strings.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies/
+ */
+var async = require( 'async' ),
+	fs = require( 'fs' ),
+	Xgettext = require( 'xgettext-js' ),
+	preProcessXGettextJSMatch = require( './preprocess-xgettextjs-match.js' ),
+	parser;
+
+// parser object that buids a WordPress php string for every
+// occurence of `translate()` in a file
+parser = new Xgettext( {
+	keywords: {
+		translate: function( match ) {
+			var finalProps = preProcessXGettextJSMatch( match );
+
+			if ( ! finalProps ) {
+				return; // invalid input, skip this match
+			}
+			return buildWordPressString( finalProps );
+		},
+	}
+} );
+
+/**
+ * Determine the correct WP i18n function to use based on the input:
+ * __(), _n(), _nx(), _x()
+ * @param  {object} properties - properties describing translation request
+ * @return {string}            returns the function name
+ */
+function getWordPressFunction( properties ) {
+	var wpFunc = [ '_' ];
+
+	if ( properties.plural ) {
+		wpFunc.push( 'n' );
+	}
+	if ( properties.context ) {
+		wpFunc.push( 'x' );
+	}
+
+	wpFunc = wpFunc.join( '' );
+
+	if ( 1 === wpFunc.length ) {
+		return '__';
+	}
+
+	return wpFunc;
+}
+
+/**
+ * Generate each line of equivalent php from a matching `translate()`
+ * request found in the client code
+ * @param  {object} properties - properties describing translation request
+ * @return {string}            the equivalent php code for each translation request
+ */
+function buildWordPressString( properties ) {
+	var wpFunc = getWordPressFunction( properties ),
+		response = [],
+		stringFromFunc = {
+			__: '\n__( ' + properties.single + ' ),',
+			_x: '\n_x( ' + [ properties.single, properties.context ].join( ', ' ) + ' ),',
+			_nx: '\n_nx( ' + [ properties.single, properties.plural, properties.count, properties.context ].join( ', ' ) + ' ),',
+			_n: '\n_n( ' + [ properties.single, properties.plural, properties.count ].join( ', ' ) + ' ),'
+		};
+
+	// translations with comments get a preceding comment in the php code
+	if ( properties.comment ) {
+		// replace */ with *\/ to prevent translators from accidentally running arbitrary code
+		response.push( '\n/* translators: ' + properties.comment.replace( /\*\//g, '*\\/' ) + ' */' );
+	}
+
+	response.push( stringFromFunc[ wpFunc ] );
+
+	return response.join( '' );
+}
+
+/**
+ * Takes read file and generates a string representation of a file with
+ * equivalent WordPress-style translate functions. Also prepends with some
+ * necessary time and number translations.
+ *
+ * @param  {array} data        - the input file as read in by fs.readFile()
+ * @param  {string} arrayName  - name of the array in the php resulting php file
+ * @return {string}            - string representation of the final php file
+ */
+function buildPhpOutput( data, arrayName ) {
+	// find matching instances of `translate()` and generate corresponding php output
+	var matches = parser.getMatches( data );
+	console.log( matches );
+
+	matches = matches.map( function( match ) {
+		return match.string;
+	} );
+
+	// prepend the matches array with this content to open the php file
+	matches.unshift( [
+		'<?php',
+		'\n/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. SEE https://github.com/Automattic/wp-calypso/tree/master/server/i18n */',
+		'\n$' + arrayName + ' = array('
+	].join( '' ) );
+
+	// append the matches array with this content to close the php file
+	matches.push( [
+		'\n\n// Date/time strings for localisation',
+		'\n_x( "in %s", "future time" ),',
+		'\n__( "a few seconds" ),',
+		'\n__( "a minute" ),',
+		'\n__( "%d minutes" ),',
+		'\n__( "%d hours" ),',
+		'\n__( "%d days" ),',
+		'\n__( "a month" ),',
+		'\n__( "%d months" ),',
+		'\n__( "a year" ),',
+		'\n__( "%d years" ),',
+		'\n\n// Momentjs formatting strings',
+
+		'\n\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "HH:mm", "momentjs format string (for LT)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "DD/MM/YYYY", "momentjs format string (for L)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "D MMMM YYYY", "momentjs format string (for LL)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "D MMMM YYYY LT", "momentjs format string (for LLL)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "dddd, D MMMM YYYY LT", "momentjs format string (for LLLL)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "MMM D", "momentjs format string (for MMM D)" ),',
+
+		'\n\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "[Today at] LT", "momentjs format string (sameDay)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "[Tomorrow at] LT", "momentjs format string (nextDay)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "dddd [at] LT", "momentjs format string (nextWeek)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "[Yesterday at] LT", "momentjs format string (lastDay)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "[Last] dddd [at] LT", "momentjs format string (lastWeek)" ),',
+		'\n/* translators: Moment.js formatting string, see http://momentjs.com/docs/#/displaying/format/ and https://github.com/moment/moment/blob/develop/locale/en-gb.js, surround non-variable text with square brackets */',
+		'\n_x( "L", "momentjs format string (sameElse)" ),',
+
+		'\n\n/* translators: Number representing the first day of the week, 0=Sunday, 1=Monday, etc. Should match typical region formats for the most prominent region where the language is spoken. */',
+		'\n_x( "num_first_day_of_week", "momentjs setting" ),',
+		'\n/* translators: The week that contains Jan (X) is the first week of the year, e.g., `4` means Jan 4. Different regions start counting weeks with different rules, check Wikipedia to be sure. */',
+		'\n_x( "num_day_of_year", "momentjs setting" ),',
+		'\n);\n'
+	].join( '' ) );
+
+	// append the generated file comment to the bottom of the array as well
+	matches.push( '\n/* THIS IS THE END OF THE GENERATED FILE */' );
+
+	return matches.join( '' );
+}
+
+/**
+ * Reads the inputFile and generates a php outputFile with equivalent php translation functions.
+
+ * @param  {string}   outputFile - location to save the resulting output file
+ * @param  {string}   arrayName  - name of array to use inside php file
+ * @param  {string}   inputFiles  - location of the javascript file to parse
+ * @param  {Function} done       - callback function
+ */
+function readFile( outputFile, arrayName, inputFiles, done ) {
+	console.log( 'Reading inputFiles: ' + inputFiles.join( ', ' ) );
+	async.map( inputFiles, function( inputFile, callback ) {
+		fs.readFile( inputFile, 'utf8', function( err, data ) {
+			if ( err ) {
+				console.log( 'i18n: Error reading ' + inputFile );
+				callback( err );
+			} else {
+				callback( null, data );
+			}
+		} );
+	}, function( err, data ) {
+		if ( err ) {
+			return console.log( err );
+		}
+		fs.writeFile( outputFile, buildPhpOutput( data.join( '\n' ), arrayName ), 'utf8', function( error ) {
+			if ( error ) {
+				console.log( error );
+			} else {
+				console.log( 'get-i18n completed' );
+				if ( 'function' === typeof done ) {
+					done();
+				}
+			}
+		} );
+	} );
+}
+
+module.exports = readFile;

--- a/lib/glotpress/preprocess-xgettextjs-match.js
+++ b/lib/glotpress/preprocess-xgettextjs-match.js
@@ -1,0 +1,107 @@
+/**
+ * Takes an xgettext-js match and processes it into a form more easily consumed
+ * by server-side i18n functions.
+ *
+ * Returns an object  *
+ * Specifically:
+ *  - facilitates simple string concatenation inside translate,
+ *     e.g. translate( "A long string " + "broken up over multiple lines" ),
+ *  - wraps quotes and backslashes for php consumption
+ *
+ * @param  {object} match - parser matching object
+ * @return {object} data object combining the strings and options passed into translate();
+ */
+module.exports = function preProcessXGettextJSMatch( match ) {
+	var finalProps = {},
+		options, i, keyName, args;
+
+	if ( ! match.arguments.length ) {
+		return;
+	}
+
+	args = match.arguments;
+
+	// first string argument
+	if ( args[ 0 ].type === 'Literal' ) {
+		finalProps.single = args[ 0 ].raw;
+	} else if ( args[ 0 ].type === 'BinaryExpression' ) {
+		finalProps.single = encapsulateString( concatenateBinaryExpression( args[ 0 ] ) );
+	}
+
+	// second string argument
+	if ( args[ 1 ] ) {
+		if ( args[ 1 ].type === 'Literal' ) {
+			finalProps.plural = args[ 1 ].raw;
+		} else if ( args[ 1 ].type === 'BinaryExpression' ) {
+			finalProps.plural = encapsulateString( concatenateBinaryExpression( args[ 1 ] ) );
+		}
+	}
+
+	// options could be in position 0, 1, or 2, but there can only be one
+	for ( i = 0; i < args.length; i++ ) {
+		if ( args[ i ].type === 'ObjectExpression' ) {
+			options = args[ i ];
+			break;
+		}
+	}
+
+	if ( 'undefined' !== typeof options ) {
+		// map options to finalProps object
+		options.properties.forEach( function( property ) {
+			// key might be an  Identifier (name), or a Literal (value)
+			var key = property.key.name || property.key.value;
+			if ( 'Literal' === property.value.type ) {
+				keyName = ( key === 'original' ) ? 'single' : key;
+				finalProps[ keyName ] = ( 'comment' === key ) ? property.value.value : property.value.raw;
+			} else if ( 'ObjectExpression' === property.value.type && 'original' === key ) {
+				// Get pluralization strings. This clause can be removed when all translations
+				// are updated to the new approach for plurals.
+				property.value.properties.forEach( function( innerProp ) {
+					finalProps[ innerProp.key.name || innerProp.key.value ] = innerProp.value.raw;
+				} );
+			}
+		} );
+	}
+
+	// We don't care about the actual count value on the server, we just want to
+	// register the translation string in GlotPress, and the real count value
+	// will be used on the client to determine which plural version to display.
+	if ( typeof finalProps.plural !== 'undefined' ) {
+		finalProps.count = 1;
+	}
+
+	// Brittle test to check for collision of the method name because d3
+	// also provides a translate() method. Longer-term solution would be
+	// better namespacing.
+	if ( ! finalProps.single ) {
+		return false;
+	}
+
+	return finalProps;
+};
+
+/**
+ * Long translation strings can be broken into multiple strings concatenated with the + operator.
+ * This function concatenates the substrings into a single string.
+ * @param  {object} ASTNode - the BinaryExpression object returned from the AST parser
+ * @return {string}          - the concatenated string
+ */
+function concatenateBinaryExpression( ASTNode ) {
+	var result;
+	if ( ASTNode.operator !== '+' ) {
+		return false;
+	}
+	result = ( ASTNode.left.type === 'Literal' ) ? ASTNode.left.value : concatenateBinaryExpression( ASTNode.left );
+	result += ( ASTNode.right.type === 'Literal' ) ? ASTNode.right.value : concatenateBinaryExpression( ASTNode.right );
+
+	return result;
+}
+
+/**
+ * Takes a string argument and turns it into a valid php representation of that string
+ * @param  {string} string - origin string
+ * @return {string}        - php representation of string
+ */
+function encapsulateString( string ) {
+	return "'" + string.replace( /(\\|\')/g, '\\$1' ) + "'";
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "npm install && node build/server.bundle",
     "qs": "npm run build && node build/server.bundle",
     "prod": "NODE_ENV=production node build/server.bundle",
-    "postinstall": "npm run-script build"
+    "postinstall": "npm run-script build",
+    "translate": "bin/get-i18n delphin_i18n_strings.php delphin_i18n_strings build/client.bundle.js build/server.bundle.js"
   },
   "repository": {
     "type": "git",
@@ -25,11 +26,14 @@
   },
   "homepage": "https://github.com/Automattic/delphin#readme",
   "devDependencies": {
+    "async": "^2.0.0-rc.3",
     "babel-eslint": "^6.0.2",
+    "commander": "^2.9.0",
     "eslint": "^2.2.0",
     "eslint-plugin-react": "^4.3.0",
     "eslint-plugin-wpcalypso": "^1.1.3",
-    "node-sass": "^3.4.2"
+    "node-sass": "^3.4.2",
+    "xgettext-js": "^0.3.0"
   },
   "dependencies": {
     "babel-core": "^6.7.4",


### PR DESCRIPTION
This adds a script which generates a php file that can be copied to WordPress.com, so that the translations for delphin can be added to GlotPress.

All of this code is copied from Calypso. I just changed a few file names and paths.
#### Testing instructions
1. Run `git checkout add/script-to-generate-i18n-strings`
2. Run `npm run translate`
3. Check that a `delphin-i18n-strings.php` file is generated in the root of the application, and contains all of the strings that are currently translated.
#### Reviews
- [x] Code
- [x] Product
