### PR TITLE
Upgrade to Node 5.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lodash": "^4.6.1",
     "lru-cache": "^4.0.1",
     "moment-timezone": "^0.5.3",
+    "node-sass": "^3.5.3",
     "pug": "^2.0.0-alpha3",
     "react": "^15.0.1",
     "react-addons-create-fragment": "^15.0.1",


### PR DESCRIPTION
#### Testing instructions
1. Install node 5.10.1 locally. You might want to use <a href="https://github.com/creationix/nvm">nvm</a>
2. Run `git checkout update/node-version` and start your server
3. http://delphin.localhost:1337 and assert that everything works well
#### Additional notes

Also test with delphin bootstrap: https://github.com/Automattic/delphin-bootstrap/pull/1

You might need to remove your node modules and reinstall to make this work
#### Reviews
- [x] Code
- [x] Product
