### PR TITLE
Send a 404 status code when the user is requesting a route that doesn't exist

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -28,7 +28,8 @@ export default {
 		},
 		{
 			path: '*',
-			component: NotFound
+			component: NotFound,
+			slug: 'notFound'
 		}
 	]
 };

--- a/server/index.js
+++ b/server/index.js
@@ -45,11 +45,6 @@ app.use( api() );
 
 app.get( '/*', ( request, response ) => {
 	match( { routes, location: request.url }, ( error, redirectLocations, props ) => {
-		if ( ! props ) {
-			response.status( 404 ).send( 'Not found.' );
-			return;
-		}
-
 		const redirect = find( serverRedirectRoutes, route => {
 			return request.url.substring( 1 ).startsWith( route.from );
 		} );
@@ -71,6 +66,10 @@ app.get( '/*', ( request, response ) => {
 				<RouterContext { ...props } />
 			</Provider>
 		);
+
+		if ( props.routes.some( route => route.slug === 'notFound' ) ) {
+			response.status( 404 );
+		}
 
 		response.send( templateCompiler( { content: appHtml } ) );
 	} );

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -1,7 +1,7 @@
 doctype html
 html
 	head
-		script(src="build/client.bundle.js" async)
+		script(src="/build/client.bundle.js" async)
 		meta(name="viewport" content="width=device-width, initial-scale=1")
 
 	body(style="margin: 0; padding: 0;")


### PR DESCRIPTION
This adds 404 status when you visit a route that isn't defined.
#### Testing instructions
1. Run `git checkout fix/404` and start your server
2. Open http://delphin.localhost:1337/404 and assert that the response has a 404 status code
3. Open http://delphin.localhost:1337/about and assert that the response has a 304 (or 200) status code
#### Reviews
- [x] Code
- [x] Product
