### PR TITLE
Framework: fix allow secrets to be given via an environment variable for production

### DIFF
--- a/server/wpcom-rest-api-proxy/index.js
+++ b/server/wpcom-rest-api-proxy/index.js
@@ -2,8 +2,25 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import WPCOM from 'wpcom';
+import fs from 'fs';
 
-const secrets = process.env.SECRETS ? JSON.parse( process.env.SECRETS ) : require( 'server/secrets.json' );
+let rest_api_oauth_client_id = process.env.REST_API_OAUTH_CLIENT_ID,
+	rest_api_oauth_client_secret = process.env.REST_API_OAUTH_CLIENT_SECRET;
+
+if ( ! rest_api_oauth_client_id && fileExists( 'server/secrets.json' ) ) {
+	const secrets = require( 'server/secrets.json' );
+	rest_api_oauth_client_id = secrets.wordpress.rest_api_oauth_client_id;
+	rest_api_oauth_client_secret = secrets.wordpress.rest_api_oauth_client_secret;
+}
+
+function fileExists( path ) {
+	try {
+		fs.accessSync( path, fs.R_OK );
+		return true;
+	} catch ( err ) {
+		return false;
+	}
+}
 
 module.exports = function wpcomRestApiProxy() {
 	const app = express();
@@ -12,8 +29,8 @@ module.exports = function wpcomRestApiProxy() {
 
 	app.post( '/users/new', function( request, response ) {
 		const payload = Object.assign( {}, request.body, {
-			client_id: secrets.wordpress.rest_api_oauth_client_id,
-			client_secret: secrets.wordpress.rest_api_oauth_client_secret
+			client_id: rest_api_oauth_client_id,
+			client_secret: rest_api_oauth_client_secret
 		} );
 
 		WPCOM().req.post( '/users/new', payload, function( error, results ) {
@@ -23,8 +40,8 @@ module.exports = function wpcomRestApiProxy() {
 
 	app.post( '/sites/new', function( request, response ) {
 		const payload = Object.assign( {}, request.body, {
-			client_id: secrets.wordpress.rest_api_oauth_client_id,
-			client_secret: secrets.wordpress.rest_api_oauth_client_secret
+			client_id: rest_api_oauth_client_id,
+			client_secret: rest_api_oauth_client_secret
 		} );
 
 		if ( ! payload.bearer_token ) {


### PR DESCRIPTION
The global variable environment in JSON does not seem to work on heroku (enven though it works on my computer with the proper escaping). Let's use 2 variables instead.
