### PR TITLE
Framework: fix how the secrets file is read

### DIFF
--- a/server/wpcom-rest-api-proxy/index.js
+++ b/server/wpcom-rest-api-proxy/index.js
@@ -8,7 +8,7 @@ let rest_api_oauth_client_id = process.env.REST_API_OAUTH_CLIENT_ID,
 	rest_api_oauth_client_secret = process.env.REST_API_OAUTH_CLIENT_SECRET;
 
 if ( ! rest_api_oauth_client_id && fileExists( 'server/secrets.json' ) ) {
-	const secrets = require( 'server/secrets.json' );
+	const secrets = JSON.parse( fs.readFileSync( 'server/secrets.json' ) );
 	rest_api_oauth_client_id = secrets.wordpress.rest_api_oauth_client_id;
 	rest_api_oauth_client_secret = secrets.wordpress.rest_api_oauth_client_secret;
 }


### PR DESCRIPTION
It seems require() calls are inlined ontop of the module by webpack, we should be careful with this behavior...
