### PR TITLE
Framework: Fix `main` property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "delphin",
   "version": "0.0.1",
   "description": "A registrar client",
-  "main": "server/index.js",
+  "main": "server/build/bundle.js",
   "scripts": {
     "build": "npm run build:client && npm run build:server",
     "build:client": "webpack --config webpack.client.config.js --progress --colors",


### PR DESCRIPTION
`main` is the default entry file that is run when an external tool references this project.
This is a good convention to have and is required to make `calypso-live-branches` work with `delphin`.
