### PR TITLE
Remove Open Sans

### DIFF
--- a/app/components/ui/root/styles.scss
+++ b/app/components/ui/root/styles.scss
@@ -1,6 +1,6 @@
 .root {
-	color: #2e4453;;
-	font-family: "Open Sans", Helvetica, sans-serif;
+	color: #2e4453;
+	font-family: Helvetica, sans-serif;
 }
 
 .header {


### PR DESCRIPTION
We removed Open Sans on Calypso:
https://github.com/Automattic/wp-calypso/pull/3016

We shouldn't use it on Delphin either, not least because the fonts render unstyled first.
