### PR TITLE
Domain search: Use domainsbot instead of namegen

### DIFF
--- a/app/actions/domain-search.js
+++ b/app/actions/domain-search.js
@@ -35,7 +35,8 @@ export function fetchDomainSuggestions( query ) {
 		const payload = {
 			query,
 			quantity: 10,
-			include_wordpressdotcom: false
+			include_wordpressdotcom: false,
+			vendor: 'domainsbot'
 		};
 
 		wpcomAPI.req.get( '/domains/suggestions', payload, ( error, results ) => {


### PR DESCRIPTION
This pull request switches domain search to use domainsbot.
#### Testing instructions
1. Run `git checkout update/domainsbot` and start your server
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Do a domain search for `haha`
4. Check that you are using the domainsbot vendor by looking at the request in the Network tab:
   <img width="342" alt="screen shot 2016-05-11 at 15 10 56" src="https://cloud.githubusercontent.com/assets/275961/15183915/163478da-178b-11e6-933c-23dd91a5f58e.png">
#### Reviews
- [x] Code
- [x] Product
