### PR TITLE
Search: Fix the header to the top on the search page

### DIFF
--- a/app/components/ui/layout/header/search.js
+++ b/app/components/ui/layout/header/search.js
@@ -11,13 +11,15 @@ import styles from './styles.scss';
 const SearchHeader = ( props ) => {
 	return (
 		<div>
-			<header className={ styles.header }>
-				<SearchForm { ...props } />
+			<div className={ styles.searchHeaderWrapper }>
+				<header className={ styles.searchHeader }>
+					<SearchForm { ...props } />
 
-				<Link className={ styles.title } to={ getPath( 'home' ) }>
-					<h1>MagicDomains</h1>
-				</Link>
-			</header>
+					<Link className={ styles.title } to={ getPath( 'home' ) }>
+						<h1>MagicDomains</h1>
+					</Link>
+				</header>
+			</div>
 
 			<div className={ styles.contentWithSearchHeader }>
 				{ props.children }

--- a/app/components/ui/layout/header/styles.scss
+++ b/app/components/ui/layout/header/styles.scss
@@ -7,6 +7,19 @@
 	align-items: center;
 }
 
+.search-header-wrapper {
+	height: 115px;
+}
+
+.search-header {
+	@extend .header;
+
+	position: fixed;
+		left: 0;
+		right: 0;
+		top: 0;
+}
+
 .title {
 	color: #fff;
 	font-size: 2.0rem;


### PR DESCRIPTION
This pull request fixes the header on the search page to the top of the screen

<img width="677" alt="screen shot 2016-05-18 at 12 18 52" src="https://cloud.githubusercontent.com/assets/275961/15356768/b7f9f412-1cf2-11e6-96b6-638d2c79c079.png">
#### Testing instructions
1. Run `git checkout update/search-header` and start your server
2. Open http://delphin.localhost:1337/search?q=hello+chocolate+cake&r=18
3. Check that when you scroll down, the header stay at the top of the page
#### Additional notes

Check that the header isn't fixed on other pages
#### Reviews
- [x] Code
- [x] Product
