### PR TITLE
Host images on WordPress.com so we can host delphin on a8cdelphin.wordpress.com

### DIFF
--- a/app/components/ui/layout/header/styles.scss
+++ b/app/components/ui/layout/header/styles.scss
@@ -1,5 +1,5 @@
 .header {
-	background: url( /images/background.png ) center top #87a6bc;
+	background: url( http://s.wordpress.com/i/delphin/background.png ) center top #87a6bc;
 	box-shadow: 0px -10px 10px -10px rgba(0, 0, 0, 0.3) inset;
 
 	display: flex;

--- a/app/components/ui/search-input/styles.scss
+++ b/app/components/ui/search-input/styles.scss
@@ -53,11 +53,11 @@
 }
 
 .keyword-delete {
-	background: url('/images/trash.svg') center no-repeat $dark-gray-blue;
+	background: url( http://s.wordpress.com/i/delphin/trash.svg ) center no-repeat $dark-gray-blue;
 }
 
 .keyword-select {
-	background: url('/images/right-arrow.svg') center no-repeat $dark-gray-blue;
+	background: url( http://s.wordpress.com/i/delphin/right-arrow.svg ) center no-repeat $dark-gray-blue;
 }
 
 .domain-delete {

--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -123,7 +123,7 @@
 
 .sort-select {
 	appearance: none;
-	background: url( /images/form-ui-select.png ) no-repeat right center;
+	background: url( http://s.wordpress.com/i/delphin/form-ui-select.png ) no-repeat right center;
 	background-size: 50px 63px;
 	font-size: 1.8rem;
 	height: 61px;


### PR DESCRIPTION
This updates the URL for our images so we can host Delphin on a8cdelphin.

This is only a temporary measure while we host Delphin as a WordPress.com theme.
#### Testing instructions
1. Run `git checkout update/images` and start your server
2. Open the [`Search` page](http://delphin.localhost:1337/search?q=123)
3. Check that these images load:
4. Background image in the header
5. Image on the sort drop down
6. Right arrow on the keyword
7. Trash can on the keyword
#### Reviews
- [x] Code
- [x] Product
