### PR TITLE
Remove heroku auto-deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,4 @@
 deployment:
-  staging:
-    branch: master
-    heroku:
-      appname: delphin
   production:
     branch: master
     commands:


### PR DESCRIPTION
heroku hasn’t been working for a while and was making circle-ci fail on master
