### PR TITLE
Rename /login so it works when Delphin is deployed as a theme

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -53,7 +53,7 @@ export const defaultRoutes = [
 				component: CheckoutContainer
 			},
 			{
-				path: 'login',
+				path: 'log-in',
 				slug: 'loginUser',
 				static: true,
 				component: LoginContainer


### PR DESCRIPTION
The theme version of Delphin currently deployed on `a8cdelphin`
does not receive `/login` requests. The nginx front-end redirects you to `/wp-login.php`.
The temporary fix is to rename this path to `/log-in`.
## Testing instructions
- Checkout this branch and start the server
- Check that http://delphin.localhost:1337/log-in works
## Reviews
- [x] Code
- [x] Product
