### PR TITLE
Fix layout issues in Contact Information page with Firefox

### DIFF
--- a/app/components/ui/contact-information/styles.scss
+++ b/app/components/ui/contact-information/styles.scss
@@ -21,9 +21,9 @@
 .form {
 	background: $light-blue;
 	margin: 0 auto;
-	max-width: 320px;
 	padding: 20px;
 	text-align: left;
+	width: 320px;
 }
 
 .addressLineOne,
@@ -45,21 +45,24 @@
 	width: 100%;
 }
 
-.city, .state, .zip {
-	display: inline-block;
-}
-
-.state {
-	margin: 0 10px 10px 10px;
-}
-
-.city {
-	width: 140%;
-}
-
 .row {
-	display: flex;
-	justify-content: space-between;
+	.city, .state, .zip {
+		display: inline-block;
+	}
+
+	.city {
+		width: 150px;
+	}
+
+	.state {
+		margin-left: 10px;
+		width: 70px;
+	}
+
+	.zip {
+		margin-left: 10px;
+		width: 80px;
+	}
 }
 
 .label {
@@ -69,7 +72,6 @@
 }
 
 .fieldset {
-	display: block;
 	margin-bottom: 15px;
 
 	&:last-child {


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/delphin/issues/127 by making sure the form of the `Contact Information` page displays correctly under Firefox:

![screenshot](https://cloud.githubusercontent.com/assets/594356/15717470/74cd54d2-2827-11e6-9982-49f49eb26bd5.png)
#### Testing instructions
1. Run `git checkout fix/contact-information-in-firefox` and start your server
2. Open the [`Login` page](http://delphin.localhost:1337/login) and proceed until you're logged in
3. Open the [`Contact Information` page](http://delphin.localhost:1337/contact-information) and check that the form displays correctly

You may want to check different browsers and viewport sizes.
#### Additional notes

After fighting way too long with [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) I decided to go back to simply using `inline-block` (which works great here since the form has a fixed width).
#### Reviews
- [x] Code
- [x] Product
