### PR TITLE
Account: Fix API errors not displayed on the Verify User page

### DIFF
--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -123,15 +123,11 @@ export function verifyUser( email, code, twoFactorAuthenticationCode ) {
 				} );
 
 				if ( error.error === 'invalid_verification_code' ) {
-					Promise.reject( { code: error.message } );
-
-					return;
+					return Promise.reject( { code: error.message } );
 				}
 
 				if ( error.error === 'invalid_2FA_code' ) {
-					Promise.reject( { twoFactorAuthenticationCode: error.message } );
-
-					return;
+					return Promise.reject( { twoFactorAuthenticationCode: error.message } );
 				}
 
 				// If the error isn't invalid_verification_code or invalid_2FA_code


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/delphin/issues/123 by updating the `Verify User` page to display errors returned by the WordPres.com API. Previously only errors from the validation performed client-side would be displayed (such as a confirmation code with an invalid format): 

![screenshot](https://cloud.githubusercontent.com/assets/594356/15824172/2b6fb11a-2bfe-11e6-9df7-49ca82949cc3.png)
#### Testing instructions
1. Run `git checkout fix/verify-user-validation` and start your server
2. Open the [`Login` page](http://delphin.localhost:1337/login)
3. Enter an email address and submit the form
4. Enter an invalid six digits number in the `Confirmation code` field
5. Check that the `Invalid verification code` error is displayed below

You might want to try with an account that has two steps authentication enabled to be able to test the validation of the corresponding code.
#### Reviews
- [x] Code
- [x] Product
- [x] Tests
