### PR TITLE
Request related words over SSL

### DIFF
--- a/client/related-words-middleware/index.js
+++ b/client/related-words-middleware/index.js
@@ -26,7 +26,7 @@ export const relatedWordsMiddleware = store => next => action => {
 			} );
 
 			request
-				.get( `http://api.wordnik.com/v4/word.json/${ word }/relatedWords` +
+				.get( `https://api.wordnik.com/v4/word.json/${ word }/relatedWords` +
 					'?useCanonical=true' +
 					'&relationshipTypes=same-context,synonym' +
 					'&limitPerRelationshipType=3' +


### PR DESCRIPTION
This is required, because we're serving Delphin over SSL in production. This is a one-character bug fix that is preventing us from user testing so I'm just going to merge it.
