### PR TITLE
Don't consider searches without a TLD to be domain searches

### DIFF
--- a/app/lib/domains/index.js
+++ b/app/lib/domains/index.js
@@ -57,7 +57,7 @@ export function secondLevelDomainOf( validDomain ) {
  * @returns {boolean}    - the result of the test
  */
 export function isDomainSearch( value ) {
-	return isValidSecondLevelDomain( value ) || ( isDomain( value ) && domainEndsInAvailableTldRegEx.test( value ) );
+	return isDomain( value ) && domainEndsInAvailableTldRegEx.test( value );
 }
 
 /**

--- a/app/lib/domains/tests/index.js
+++ b/app/lib/domains/tests/index.js
@@ -1,7 +1,7 @@
 jest.disableAutomock();
 
 // Internal dependencies
-import { isDomain, isValidSecondLevelDomain, secondLevelDomainOf, omitTld, queryIsInResults } from '..';
+import { isDomain, isDomainSearch, isValidSecondLevelDomain, secondLevelDomainOf, omitTld, queryIsInResults } from '..';
 
 describe( 'lib/domains', () => {
 	describe( 'isDomain', () => {
@@ -96,6 +96,27 @@ describe( 'lib/domains', () => {
 			expect( omitTld( 'foo.thisisalongtld' ) ).toBe( 'foo' );
 			expect( omitTld( 'baz.' ) ).toBe( 'baz' );
 			expect( omitTld( 'foo.co.uk' ) ).toBe( 'foo' );
+		} );
+	} );
+
+	describe( 'isDomainSearch', () => {
+		it( 'should return true for valid .live domains', () => {
+			expect( isDomainSearch( 'foo.live' ) ).toBe( true );
+			expect( isDomainSearch( 'foo-bar.live' ) ).toBe( true );
+			expect( isDomainSearch( 'foo0.live' ) ).toBe( true );
+		} );
+
+		it( 'should return false for invalid .live domains', () => {
+			expect( isDomainSearch( 'foo-.live' ) ).toBe( false );
+			expect( isDomainSearch( 'foo bar.live' ) ).toBe( false );
+		} );
+
+		it( 'should return false for non-.live domains', () => {
+			expect( isDomainSearch( 'foo.com' ) ).toBe( false );
+		} );
+
+		it( 'should return false for strings without a TLD suffix', () => {
+			expect( isDomainSearch( 'foo' ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #143.

![screen shot 2016-06-08 at 2 32 48 pm](https://cloud.githubusercontent.com/assets/1130674/15911739/e61963ac-2d85-11e6-9b6d-339737090657.png)

**Testing**
- Visit `/`
- Search for a `.live` domain that is registered, e.g. `cheese.live`.
- Assert that you see a message at the top of the page that reads "Darn, cheese.live has already been snatched up!".
- Search for a keyword for which a `.live` domain is already registered, e.g. `cheese`.
- Assert that you do not see a message at the top of the page that reads "Darn, cheese.live has already been snatched up!".
- [x] Product
- [x] Code
