### PR TITLE
Upgrade i18n-calypso

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "npm install && node server/build/bundle",
     "start:static": "npm run prod:static && node server/static",
     "test": "NODE_PATH=.:app jest",
-    "translate": "glotpress-js -p delphin -e date -i public/scripts/bundle.js -i server/build/bundle.js -o server/build/delphin.pot"
+    "translate": "i18n-calypso -p delphin -e date -i public/scripts/bundle.js -i server/build/bundle.js -o server/build/delphin.pot"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,6 @@
     "eslint": "^2.2.0",
     "eslint-plugin-react": "^4.3.0",
     "eslint-plugin-wpcalypso": "^1.1.3",
-    "glotpress-js": "0.0.6",
     "node-sass": "^3.4.2",
     "serve-static": "^1.10.2",
     "xgettext-js": "^0.3.0"
@@ -63,7 +62,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "http-auth": "^2.3.1",
-    "i18n-calypso": "0.0.5",
+    "i18n-calypso": "1.0.8",
     "inherits": "^2.0.1",
     "isomorphic-style-loader": "^1.0.0",
     "jed": "1.0.2",


### PR DESCRIPTION
This PR upgrades i18n-calypso to the last version. Here are the changes it brings:
- Fixes a potential issue discovered in calypso https://github.com/Automattic/wp-calypso/issues/5879
- The CLI to generate a POT file was ported to i18n-calypso, we can remove our use on `glotpress-js`
- Minor fixes:
  - https://github.com/Automattic/i18n-calypso/commit/08466fac7881b7fa897d442ce768ba88047445d0
  - https://github.com/Automattic/i18n-calypso/commit/1f4e63fe439fe76cac5d7a39a92df6bbcbe801e1
  - https://github.com/Automattic/i18n-calypso/commit/9137cc3535ed99b4d16b627d04f1606f2bc8bcde
### Testing instructions:
- Check that everything works as before, especially localized urls such as `/fr`
- Check that `npm run translate` generates a valid POT file in `server/build/delphin.pot`
### Reviews
- [x] Code
- [x] Product
