### PR TITLE
Contact Information: Redirect users to Checkout page

### DIFF
--- a/app/components/containers/contact-information.js
+++ b/app/components/containers/contact-information.js
@@ -48,6 +48,7 @@ export default reduxForm(
 			showAddress2Input,
 			showOrganizationInput,
 			resetInputVisibility,
+			redirectToCheckout: () => push( getPath( 'checkout' ) ),
 			redirectToHome: () => push( getPath( 'home' ) ),
 			validateContactInformation: ( domainName, contactInformation ) => (
 				validateContactInformation( [ domainName ], contactInformation )

--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -1,6 +1,7 @@
 // External dependencies
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
+import isEmpty from 'lodash/isEmpty';
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
@@ -120,7 +121,11 @@ class ContactInformation extends React.Component {
 		return this.props.validateContactInformation(
 			this.props.domain,
 			contactInformation
-		);
+		).then( () => {
+			if ( isEmpty( this.props.errors ) ) {
+				this.props.redirectToCheckout();
+			}
+		} );
 	}
 
 	render() {
@@ -281,6 +286,7 @@ ContactInformation.propTypes = {
 	isLoggedIn: PropTypes.bool.isRequired,
 	isLoggedOut: PropTypes.bool.isRequired,
 	location: PropTypes.object.isRequired,
+	redirectToCheckout: PropTypes.func.isRequired,
 	redirectToHome: PropTypes.func.isRequired,
 	resetInputVisibility: PropTypes.func.isRequired,
 	showAddress2Input: PropTypes.func.isRequired,


### PR DESCRIPTION
This pull request updates the `Contact Information` page to redirect users on the `Checkout` page when the data entered is valid.

![screenshot](https://cloud.githubusercontent.com/assets/594356/15965839/821c2672-2f20-11e6-85ad-80e618476415.png)
#### Testing instructions
1. Run `git checkout add/redirect-to-checkout` and start your server, or open a [live branch](https://delphin.live/?branch=add/redirect-to-checkout)
2. Open the [`Home` page](http://delphin.localhost:1337/) and search for a domain
3. Proceed until you reach the `Contact Information` page
4. Enter invalid data and click the `Continue to Checkout` button
5. Check that validation errors are displayed
6. Enter valid data and click the `Continue to Checkout` button
7. Check that you are redirected to the `Checkout` page
#### Reviews
- [x] Code
- [x] Product
- [x] Tests
