### PR TITLE
Account: Hide login notice on page change

### DIFF
--- a/app/reducers/notices/index.js
+++ b/app/reducers/notices/index.js
@@ -1,5 +1,6 @@
 // External dependencies
 import uniqueId from 'lodash/uniqueId';
+import { LOCATION_CHANGE } from 'react-router-redux';
 
 // Internal dependencies
 import {
@@ -11,6 +12,10 @@ export function notices( state = [], action ) {
 	const { notice, type } = action;
 
 	switch ( type ) {
+		case LOCATION_CHANGE:
+			// Clears all notices whenever the user is presented with a new page
+			return [];
+
 		case NOTICE_ADD:
 			return [
 				...state,

--- a/app/reducers/notices/tests/index.js
+++ b/app/reducers/notices/tests/index.js
@@ -1,3 +1,6 @@
+// External dependencies
+import { LOCATION_CHANGE } from 'react-router-redux';
+
 // Internal dependencies
 import {
 	NOTICE_ADD,
@@ -8,11 +11,28 @@ import { notices } from '..';
 jest.unmock( '..' );
 jest.unmock( 'lodash/uniqueId' );
 
+describe( 'notices reducer for location change action', () => {
+	it( 'should clear all notices', () => {
+		const originalState = Object.freeze( [ {
+				id: '1',
+				message: 'An error message',
+				status: 'error'
+			}, {
+				id: '2',
+				message: 'Another error message',
+				status: 'error'
+			} ] ),
+			newState = notices( originalState, { type: LOCATION_CHANGE } );
+
+		expect( newState ).toEqual( [] );
+	} );
+} );
+
 describe( 'notices reducer for notice add action', () => {
 	it( 'should add a notice', () => {
 		const originalState = Object.freeze( [] ),
 			notice = {
-				message: 'A error message',
+				message: 'An error message',
 				status: 'error'
 			},
 			newState = notices( originalState, { notice, type: NOTICE_ADD } );
@@ -20,7 +40,7 @@ describe( 'notices reducer for notice add action', () => {
 		expect( newState ).toEqual( [
 			{
 				id: '1',
-				message: 'A error message',
+				message: 'An error message',
 				status: 'error'
 			}
 		] );


### PR DESCRIPTION
This pull request makes sure the success notice displayed on the `Home` page when the user logins successfully is automatically removed when navigating to another page. This is to avoid to display this notice above the search field on the `Search` page and to force the user to explicitly dismiss it by clicking the `Hide` link:

![screenshot](https://cloud.githubusercontent.com/assets/594356/15990774/697484f0-309e-11e6-931c-705a33d04604.png)

Note with this change all notices are cleared whenever the user accesses a different page.
#### Testing instructions
1. Run `git checkout update/hide-login-notice` and start your server, or open a [live branch](https://delphin.live/?branch=update/hide-login-notice)
2. Open the [`Login` page](http://delphin.localhost:1337/log-in) and log into your account
3. Check that the success notice is displayed on the `Home` page
4. Check that the notice disappears as soon as you navigate to a different page
#### Reviews
- [x] Code
- [x] Product
- [x] Tests
