### PR TITLE
Framework: Log Redux actions in console

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-tap-event-plugin": "^1.0.0",
     "redux": "^3.3.1",
     "redux-form": "^5.2.5",
+    "redux-logger": "^2.6.1",
     "redux-persist": "^3.2.2",
     "redux-thunk": "^2.0.1",
     "sass-loader": "^3.2.0",


### PR DESCRIPTION
This pull request introduces [a new middleware](https://github.com/evgenyrodionov/redux-logger) that logs Redux actions in the browser's console:

![screenshot](https://cloud.githubusercontent.com/assets/594356/15991378/94fc838a-30b1-11e6-83bf-ab09f500e4df.png)

This is a bit similar to what [DevTools for Redux](https://github.com/gaearon/redux-devtools) provides except that having actions logged right into the console put more emphasis on them, which I think is important given how central Redux is in our application. Moreover DevTools has this bug that prevents me from displaying the inspector in a separate window, meaning it's almost useless to me.

Note there is a `diff` option [in the pipe](https://github.com/evgenyrodionov/redux-logger/issues/136#issuecomment-220663008) that will allow to display a diff between the original and the new state for each action, which should be handy to spot changes in the state tree.
#### Testing instructions
1. Run `git checkout add/redux-logger` and start your server, or open a [live branch](https://delphin.live/?branch=add/redux-logger)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that actions are logged in your browser's console
#### Reviews
- [x] Code
- [x] Product
