### PR TITLE
Framework: Remove literal index exception from linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,11 +18,13 @@ module.exports = {
 		'eslint-plugin-wpcalypso'
 	],
 	'rules': {
+		'array-bracket-spacing': [ 1, 'always' ],
 		'brace-style': [ 1, '1tbs' ],
 		// REST API objects include underscores
 		'camelcase': 0,
 		'comma-dangle': 0,
 		'comma-spacing': 1,
+		'computed-property-spacing': [ 1, 'always' ],
 		// Allows returning early as undefined
 		'consistent-return': 0,
 		'dot-notation': 1,
@@ -70,6 +72,7 @@ module.exports = {
 		'react/jsx-curly-spacing': [ 1, 'always' ],
 		// Allows function use before declaration
 		'no-use-before-define': [ 2, 'nofunc' ],
+		'object-curly-spacing': [ 1, 'always' ],
 		// We split external, internal, module variables
 		'one-var': 0,
 		'operator-linebreak': [ 1, 'after', {
@@ -85,8 +88,6 @@ module.exports = {
 		'semi-spacing': 1,
 		'space-before-blocks': [ 1, 'always' ],
 		'space-before-function-paren': [ 1, 'never' ],
-		// Our array literal index exception violates this rule
-		'space-in-brackets': 0,
 		'space-in-parens': [ 1, 'always' ],
 		'space-infix-ops': [ 1, { 'int32Hint': false } ],
 		// Ideal for '!' but not for '++'

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -50,10 +50,10 @@ function getPaygateParameters( cardDetails ) {
 		name: cardDetails.name,
 		number: cardDetails.number,
 		cvc: cardDetails.cvv,
-		zip: cardDetails['postal-code'],
+		zip: cardDetails[ 'postal-code' ],
 		country: cardDetails.country,
-		exp_month: cardDetails['expiration-date'].substring( 0, 2 ),
-		exp_year: '20' + cardDetails['expiration-date'].substring( 3, 5 )
+		exp_month: cardDetails[ 'expiration-date' ].substring( 0, 2 ),
+		exp_year: '20' + cardDetails[ 'expiration-date' ].substring( 3, 5 )
 	};
 }
 
@@ -103,10 +103,10 @@ function createPaygateToken( requestType, cardDetails, callback ) {
 export function createTransaction( user, form ) {
 	const cardDetails = {
 		name: form.name,
-		number: form['credit-card-number'],
+		number: form[ 'credit-card-number' ],
 		cvv: form.cvv,
-		'expiration-date': form['expiration-date'],
-		'postal-code': form['postal-code']
+		'expiration-date': form[ 'expiration-date' ],
+		'postal-code': form[ 'postal-code' ]
 	};
 
 	return dispatch => {

--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -95,13 +95,13 @@ const Checkout = React.createClass( {
 				<label>{ i18n.translate( 'name' ) }</label>
 				<input type="text" name="name" />
 				<label>{ i18n.translate( 'credit card #' ) }</label>
-				<input type="text" name="credit-card-number" onChange={ this.updateForm } value={ this.state.form['credit-card-number'] } />
+				<input type="text" name="credit-card-number" onChange={ this.updateForm } value={ this.state.form[ 'credit-card-number' ] } />
 				<label>{ i18n.translate( 'cvv' ) }</label>
 				<input type="text" name="cvv" onChange={ this.updateForm } value={ this.state.form.cvv } />
 				<label>{ i18n.translate( 'expiration date in MM/YY format' ) }</label>
-				<input type="text" name="expiration-date" onChange={ this.updateForm } value={ this.state.form['expiration-date'] } placeholder="01/20" />
+				<input type="text" name="expiration-date" onChange={ this.updateForm } value={ this.state.form[ 'expiration-date' ] } placeholder="01/20" />
 				<label>{ i18n.translate( 'postal code' ) }</label>
-				<input type="text" name="postal-code" onChange={ this.updateForm } value={ this.state.form['postal-code'] } />
+				<input type="text" name="postal-code" onChange={ this.updateForm } value={ this.state.form[ 'postal-code' ] } />
 				<br />
 				<button>Checkout</button>
 			</form>

--- a/app/lib/analytics/index.js
+++ b/app/lib/analytics/index.js
@@ -178,7 +178,7 @@ const analytics = {
 				} else if ( startsWith( featureSlug, 'read_post_id_' ) ) {
 					featureSlug = 'read_post_id__id';
 				} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
-					featureSlug = `start_${matched[1]}`;
+					featureSlug = `start_${matched[ 1 ]}`;
 				}
 
 				const json = JSON.stringify( {

--- a/client/analytics-middleware/tests/middleware.js
+++ b/client/analytics-middleware/tests/middleware.js
@@ -51,7 +51,7 @@ describe( 'middleware', () => {
 		} );
 
 		it( 'should call analytics events with wrapped actions', () => {
-			dispatch( withAnalytics( bumpStat( 'name', 'value' ), { type: 'TEST_ACTION'} ) );
+			dispatch( withAnalytics( bumpStat( 'name', 'value' ), { type: 'TEST_ACTION' } ) );
 
 			expect( analytics.mc.bumpStat ).toBeCalled();
 		} );


### PR DESCRIPTION
This pull request seeks to remove an exception [recently removed](https://github.com/Automattic/wp-calypso/pull/5829) from Calypso coding standards which allowed for exceptions in our array and object spacing guideline when using numbers or string literals.
#### Testing instructions
1. Run `git checkout update/linting` and start your server, or open a [live branch](https://delphin.live/?branch=update/linting)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that everything works as before
#### Reviews
- [x] Code
- [x] Product
- [x] Tests
