### PR TITLE
Enable `redux-logger` via a local storage flag

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -35,7 +35,7 @@ const middlewares = [
 
 const isDevelopment = 'production' !== config( 'env' );
 
-if ( isDevelopment ) {
+if ( isDevelopment && localStorage.ENABLE_REDUX_LOGGER ) {
 	middlewares.push( createLogger( {
 		collapsed: true,
 		level: {


### PR DESCRIPTION
`redux-logger` makes it easy to miss errors or deliberate `console.log` / `debug` statements. This commit updates the client boot to check for the presence of an `ENABLE_REDUX_LOGGER` property in local storage before adding the middleware.

**Testing**
- Enable `redux-logger` by executing `localStorage.setItem( 'ENABLE_REDUX_LOGGER', true );` in your console.
- Refresh the page and assert that you see actions logged in the console.
- [x] Code
- [x] Product
