### PR TITLE
Remove support for persisting the Redux store via `redux-persist`

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,9 +1,8 @@
 // External dependencies
-import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 import { browserHistory } from 'react-router';
 import createLogger from 'redux-logger';
 import injectTapEventPlugin from 'react-tap-event-plugin';
-import { persistStore, autoRehydrate } from 'redux-persist';
 import { Provider } from 'react-redux';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -54,13 +53,8 @@ const store = createStore(
 		routing: routerReducer
 	} ),
 	window.devToolsExtension ? window.devToolsExtension() : f => f,
-	compose(
-		autoRehydrate(),
-		applyMiddleware( ...middlewares )
-	)
+	applyMiddleware( ...middlewares )
 );
-
-persistStore( store );
 
 // Create an enhanced history that syncs navigation events with the store
 const history = syncHistoryWithStore( browserHistory, store );

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "redux": "^3.3.1",
     "redux-form": "^5.2.5",
     "redux-logger": "^2.6.1",
-    "redux-persist": "^3.2.2",
     "redux-thunk": "^2.0.1",
     "sass-loader": "^3.2.0",
     "source-map-support": "^0.4.0",


### PR DESCRIPTION
This pull request removes support for persisting the Redux store via `redux-persist`. This indeed caused strange behaviors like being redirected to a different page when refreshing a page, as discussed in p1465923686000249-slack-delphin. It basically reverts https://github.com/Automattic/delphin/pull/175/.
#### Testing instructions
1. Run `git checkout update/remove-redux-persist` and start your server, or open a [live branch](https://delphin.live/?branch=update/remove-redux-persist)
2. Open the [`Home` page](http://delphin.localhost:1337/) and search for a domain
3. Proceed until you reach the `Contact Information` page
4. Head back to the `Home` page and hit refresh in your browser
5. Check that you are not redirected to another page
#### Reviews
- [x] Code
- [x] Product
