### PR TITLE
Contact Information: Update heading to mention the domain name being purchased

### DIFF
--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -165,7 +165,12 @@ class ContactInformation extends React.Component {
 					</h2>
 
 					<h3 className={ styles.text }>
-						{ i18n.translate( 'We need your contact information to claim your new domain.' ) }
+						{ i18n.translate( 'We need your contact information to claim {{strong}}%(domain)s{{/strong}}.',
+							{
+								args: { domain: this.props.domain },
+								components: { strong: <strong /> }
+							}
+						) }
 					</h3>
 				</div>
 


### PR DESCRIPTION
This pull request adds the actual domain chosen to the copy on the `Contact Information` page:

![screenshot](https://cloud.githubusercontent.com/assets/594356/16089657/71f32ae2-332c-11e6-8bb9-bf102aea036a.png)
#### Testing instructions
1. Run `git checkout update/contact-information-heading` and start your server, or open a [live branch](https://delphin.live/?branch=update/contact-information-heading)
2. Open the [`Home` page](http://delphin.localhost:1337/) and search for a domain
3. Proceed until you reach the `Contact Information` page
4. Check that domain name selected is now displayed in the heading
#### Reviews
- [x] Code
- [x] Product
