### PR TITLE
Search: Fix error when backspace is used on empty field

### DIFF
--- a/app/reducers/ui/domain-search/domain-keywords.js
+++ b/app/reducers/ui/domain-search/domain-keywords.js
@@ -117,6 +117,10 @@ export default function domainKeywords( state = initialState, action ) {
 			return state;
 
 		case DOMAIN_SEARCH_LAST_KEYWORD_REMOVE:
+			if ( isEmpty( state.keywords ) ) {
+				return state;
+			}
+
 			const { value: keywordValue } = last( state.keywords );
 
 			return Object.assign( {}, state, {

--- a/app/reducers/ui/domain-search/tests/domain-keywords.js
+++ b/app/reducers/ui/domain-search/tests/domain-keywords.js
@@ -125,4 +125,18 @@ describe( 'ui.domainSearch reducer', () => {
 			keywords: [ { value: 'foobar', isSelected: false } ]
 		} );
 	} );
+
+	it( 'should not change list of keywords when removing the last keyword', () => {
+		const initialState = {
+			inputValue: '',
+			keywords: []
+		};
+
+		expect( domainKeywords( initialState, {
+			type: DOMAIN_SEARCH_LAST_KEYWORD_REMOVE
+		} ) ).toEqual( {
+			inputValue: '',
+			keywords: []
+		} );
+	} );
 } );


### PR DESCRIPTION
This pull request fixes an error thrown on the `Search` page when the user hits <kbd>backspace</kbd> whereas the search field is empty:

![screenshot](https://cloud.githubusercontent.com/assets/594356/16144392/f3044da4-3472-11e6-9c84-897b81de5287.png)
#### Testing instructions
1. Run `git checkout fix/domain-search` and start your server, or open a [live branch](https://delphin.live/?branch=fix/domain-search)
2. Open the [`Search` page](http://delphin.localhost:1337/search)
3. Enter a keyword and hit <kbd>enter</kbd>
4. Hit <kbd>backspace</kbd> until the search input field is empty
5. Check that no error is thrown and that you can still look up domains
#### Additional notes

[...]
#### Reviews
- [x] Code
- [x] Product
- [x] Tests
