### PR TITLE
Framework: Add linting rule to catch missing props validation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,7 @@ module.exports = {
 		'react/no-danger': 2,
 		'react/no-did-mount-set-state': 1,
 		'react/no-did-update-set-state': 1,
+		'react/prop-types': 1,
 		'jsx-quotes': [ 1, 'prefer-double' ],
 		'react/jsx-no-bind': 1,
 		'react/jsx-curly-spacing': [ 1, 'always' ],

--- a/app/components/ui/checkout-progressbar/index.js
+++ b/app/components/ui/checkout-progressbar/index.js
@@ -45,6 +45,7 @@ function Progressbar( props ) {
 }
 
 Progressbar.propTypes = {
+	className: PropTypes.string,
 	currentStep: PropTypes.number.isRequired
 };
 

--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -16,6 +16,9 @@ import Input from 'components/ui/form/input';
 const Checkout = React.createClass( {
 	propTypes: {
 		checkout: PropTypes.object.isRequired,
+		fields: PropTypes.object.isRequired,
+		handleSubmit: PropTypes.func.isRequired,
+		initializeForm: PropTypes.func.isRequired,
 		isLoggedIn: PropTypes.bool.isRequired,
 		purchaseDomain: PropTypes.func.isRequired,
 		redirectToSearch: PropTypes.func.isRequired,

--- a/app/components/ui/connect-user/verify-user/resend-signup-email.js
+++ b/app/components/ui/connect-user/verify-user/resend-signup-email.js
@@ -9,6 +9,7 @@ import styles from './styles.scss';
 const ResendSignupEmail = React.createClass( {
 	propTypes: {
 		connectUser: PropTypes.func.isRequired,
+		intention: PropTypes.string.isRequired,
 		email: PropTypes.string.isRequired
 	},
 

--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -337,8 +337,11 @@ ContactInformation.propTypes = {
 	contactInformation: PropTypes.object.isRequired,
 	countries: PropTypes.object.isRequired,
 	domain: PropTypes.string,
+	errors: PropTypes.object,
+	fetchContactInformation: PropTypes.func.isRequired,
 	fetchCountries: PropTypes.func.isRequired,
 	fetchLocation: PropTypes.func.isRequired,
+	fetchStates: PropTypes.func.isRequired,
 	fields: PropTypes.object.isRequired,
 	handleSubmit: PropTypes.func.isRequired,
 	inputVisibility: PropTypes.object.isRequired,
@@ -352,6 +355,7 @@ ContactInformation.propTypes = {
 	showOrganizationInput: PropTypes.func.isRequired,
 	states: PropTypes.object.isRequired,
 	submitting: PropTypes.bool.isRequired,
+	untouch: PropTypes.func.isRequired,
 	user: PropTypes.object.isRequired,
 	validateContactInformation: PropTypes.func.isRequired
 };

--- a/app/components/ui/form/form-toggle/index.js
+++ b/app/components/ui/form/form-toggle/index.js
@@ -76,10 +76,15 @@ class FormToggle extends React.Component {
 }
 
 FormToggle.propTypes = {
+	'aria-label': React.PropTypes.string,
+	children: React.PropTypes.node,
 	onChange: React.PropTypes.func,
+	onKeyDown: React.PropTypes.func,
 	checked: React.PropTypes.bool,
 	disabled: React.PropTypes.bool,
-	id: React.PropTypes.string
+	id: React.PropTypes.string,
+	name: React.PropTypes.string.isRequired,
+	toggling: React.PropTypes.bool
 };
 
 FormToggle.defaultProps = {

--- a/app/components/ui/form/input.js
+++ b/app/components/ui/form/input.js
@@ -51,6 +51,7 @@ class Input extends React.Component {
 }
 
 Input.propTypes = {
+	className: PropTypes.string,
 	field: PropTypes.object.isRequired,
 	untouch: PropTypes.func
 };

--- a/app/components/ui/home/index.js
+++ b/app/components/ui/home/index.js
@@ -12,7 +12,15 @@ import styles from './styles.scss';
 
 const Home = React.createClass( {
 	propTypes: {
-		fields: PropTypes.object.isRequired
+		changeQuery: PropTypes.func.isRequired,
+		domainSearch: PropTypes.object.isRequired,
+		fetchDomainSuggestions: PropTypes.func.isRequired,
+		fields: PropTypes.object.isRequired,
+		handleSubmit: PropTypes.func.isRequired,
+		redirectToSearch: PropTypes.func.isRequired,
+		selectDomain: PropTypes.func.isRequired,
+		showEmptySearchNotice: PropTypes.bool.isRequired,
+		submitEmptySearch: PropTypes.func.isRequired
 	},
 
 	componentWillReceiveProps( nextProps ) {

--- a/app/components/ui/search-input/index.js
+++ b/app/components/ui/search-input/index.js
@@ -83,16 +83,19 @@ class SearchInput extends React.Component {
 }
 
 SearchInput.propTypes = {
+	inputValue: PropTypes.string.isRequired,
 	keywords: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		isSelected: PropTypes.bool.isRequired
 	} ) ).isRequired,
+	placeholder: PropTypes.string.isRequired,
 	selectedKeyword: PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		isSelected: PropTypes.bool.isRequired
 	} ),
 	relatedWords: PropTypes.array.isRequired,
 	removeLastKeyword: PropTypes.func.isRequired,
+	replace: PropTypes.func.isRequired,
 	submit: PropTypes.func.isRequired,
 	changeInput: PropTypes.func.isRequired
 };

--- a/app/components/ui/search-input/keyword.js
+++ b/app/components/ui/search-input/keyword.js
@@ -55,7 +55,9 @@ Keyword.propTypes = {
 	keyword: PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		isSelected: PropTypes.bool.isRequired
-	} ).isRequired
+	} ).isRequired,
+	remove: PropTypes.func.isRequired,
+	toggleSelect: PropTypes.func.isRequired
 };
 
 export default withStyles( styles )( Keyword );

--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -13,7 +13,9 @@ import SearchHeader from './header';
 
 const Search = React.createClass( {
 	propTypes: {
+		defaultTLD: PropTypes.string.isRequired,
 		fetchDomainSuggestions: PropTypes.func.isRequired,
+		isRequesting: PropTypes.bool.isRequired,
 		query: PropTypes.string.isRequired,
 		numberOfResultsToDisplay: PropTypes.number,
 		redirectToSearch: PropTypes.func.isRequired,

--- a/app/components/ui/search/suggestions.js
+++ b/app/components/ui/search/suggestions.js
@@ -18,7 +18,8 @@ const Suggestions = React.createClass( {
 	propTypes: {
 		count: PropTypes.number,
 		selectDomain: PropTypes.func.isRequired,
-		results: PropTypes.array
+		results: PropTypes.array,
+		sort: PropTypes.string.isRequired
 	},
 
 	getSortedResults() {

--- a/app/index.js
+++ b/app/index.js
@@ -1,12 +1,18 @@
 // External dependencies
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Router } from 'react-router';
 
 // Internal dependencies
 import { routes } from 'routes';
 
-export default function App( { history } ) {
+const App = function( { history } ) {
 	return (
 		<Router history={ history } routes={ routes } />
 	);
-}
+};
+
+App.propTypes = {
+	history: PropTypes.object.isRequired
+};
+
+export default App;


### PR DESCRIPTION
This pull request adds a new Eslint rule to [prevent missing props validation in a React component definition](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md). It also fixes any component that was not compliant.
#### Testing instructions
1. Run `git checkout update/linting` and start your server, or open a [live branch](https://delphin.live/?branch=update/linting)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that performing any task doesn't throw errors about wrong props in the browser's console
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
