### PR TITLE
Fix domain search with TLD

### DIFF
--- a/app/components/containers/home.js
+++ b/app/components/containers/home.js
@@ -6,6 +6,7 @@ import { reduxForm, change } from 'redux-form';
 import { fetchDomainSuggestions, selectDomain, submitEmptySearch } from 'actions/domain-search';
 import { getPath } from 'routes';
 import Home from 'components/ui/home';
+import { isLoggedIn } from 'reducers/user/selectors';
 
 export default reduxForm(
 	{
@@ -14,7 +15,8 @@ export default reduxForm(
 	},
 	state => ( {
 		domainSearch: state.domainSearch,
-		showEmptySearchNotice: state.ui.domainSearch.showEmptySearchNotice
+		showEmptySearchNotice: state.ui.domainSearch.showEmptySearchNotice,
+		isLoggedIn: isLoggedIn( state )
 	} ),
 	dispatch => ( {
 		changeQuery( query ) {
@@ -48,7 +50,7 @@ export default reduxForm(
 	} ),
 	( stateProps, dispatchProps, ownProps ) => Object.assign( {}, stateProps, dispatchProps, ownProps, {
 		selectDomain( domainProduct ) {
-			dispatchProps.selectDomain( domainProduct, stateProps.user.isLoggedIn );
+			dispatchProps.selectDomain( domainProduct, stateProps.isLoggedIn );
 		}
 	} )
 )( Home );


### PR DESCRIPTION
Fixes #206 

We were reading the `user` props which was not defined as props anymore. This PR removes the need for the `user` prop and uses the `isLoggedIn` selector instead.
### Testing Instructions
- Search for a domain and include the TLD. For instance: `hefewfwfew.live`.
- Assert that you are redirected to checkout or signin immediately (depending if you are logged in or not)
### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
