### PR TITLE
Framework: Add bind handlers helper

### DIFF
--- a/lib/class-helpers/index.js
+++ b/lib/class-helpers/index.js
@@ -1,0 +1,14 @@
+/***
+ * Binds all functions on object prototype to current instance that start with the word 'handle'
+ * @param {Object} obj The object to bind
+ */
+export function bindHandlers( obj ) {
+	if ( typeof obj !== 'object' || obj === null ) {
+		throw new Error( 'bindHandlers can handle only objects' );
+	}
+
+	Object.getOwnPropertyNames( Object.getPrototypeOf( obj ) )
+		.filter( ( prop ) => prop.indexOf( 'handle' ) === 0 )
+		.filter( ( prop ) => typeof obj[ prop ] === 'function' )
+		.forEach( ( prop ) => obj[ prop ] = obj[ prop ].bind( obj ) );
+}

--- a/lib/class-helpers/tests/index.js
+++ b/lib/class-helpers/tests/index.js
@@ -1,0 +1,29 @@
+jest.disableAutomock();
+
+// Internal dependencies
+import { bindHandlers } from '..';
+
+describe( 'bindHandlers', () => {
+	function Test( param ) {
+		this.param = param;
+		bindHandlers( this );
+	}
+
+	Test.prototype.handleClick = function() {
+		return this.param;
+	};
+
+	Test.prototype.someFunc = function() {
+		return this.param;
+	};
+
+	it( 'should bind functions that start with handle', () => {
+		const a = new Test( 'hello' );
+		expect( a.handleClick() ).toBe( 'hello' );
+	} );
+
+	it( 'should leave alone functions that doesn\'t start with handle', () => {
+		const a = new Test( 'hello' );
+		expect( a.someFunc === Test.prototype.someFunc ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
This is a module @yurynix created to obviate the need to manually set up bound event handlers in the `constructor` of each class.
