### PR TITLE
Pass correct `domain` prop to `VerifyUser`

### DIFF
--- a/app/components/containers/connect-user/verify.js
+++ b/app/components/containers/connect-user/verify.js
@@ -37,7 +37,7 @@ export default reduxForm(
 		validate
 	},
 	state => ( {
-		domain: getCheckout( state ).domain,
+		domain: getCheckout( state ).selectedDomain.domain,
 		isLoggedIn: isLoggedIn( state ),
 		user: getUserConnect( state )
 	} ),


### PR DESCRIPTION
This broke after I changed the way we store the selected domain in `state.checkout`.

Props to @spncrb for pointing this out.
