### PR TITLE
Account: Fix submit button staying disabled with wrong verification code

### DIFF
--- a/app/reducers/user/connect.js
+++ b/app/reducers/user/connect.js
@@ -8,7 +8,8 @@ import {
 	CONNECT_USER_COMPLETE,
 	CONNECT_USER_WARNING,
 	VERIFY_USER,
-	VERIFY_USER_COMPLETE
+	VERIFY_USER_COMPLETE,
+	VERIFY_USER_FAIL
 } from 'reducers/action-types';
 
 const initialState = {
@@ -71,6 +72,11 @@ export const connect = ( state = initialState, action ) => {
 				data: {
 					bearerToken
 				}
+			} );
+
+		case VERIFY_USER_FAIL:
+			return Object.assign( {}, state, {
+				isRequesting: false
 			} );
 
 		default:

--- a/app/reducers/user/tests/connect.js
+++ b/app/reducers/user/tests/connect.js
@@ -7,7 +7,8 @@ import {
 	CONNECT_USER_COMPLETE,
 	CONNECT_USER_WARNING,
 	VERIFY_USER,
-	VERIFY_USER_COMPLETE
+	VERIFY_USER_COMPLETE,
+	VERIFY_USER_FAIL
 } from 'reducers/action-types';
 import { connect } from '../connect';
 
@@ -109,5 +110,16 @@ describe( 'state.user.connect', () => {
 
 		expect( result.isRequesting ).toBe( false );
 		expect( result.data.bearerToken ).toBe( 'foobar' );
+	} );
+
+	it( 'should update `isRequesting` if the user verification fails', () => {
+		expect( connect( {
+			intention: null,
+			isRequesting: true,
+			wasCreated: false,
+			data: null
+		}, {
+			type: VERIFY_USER_FAIL
+		} ).isRequesting ).toEqual( false );
 	} );
 } );


### PR DESCRIPTION
Fixes #226.

**Testing**
- Visit `/log-in`
- Enter an email address.
- Submit.
- Enter an incorrect code.
- Submit.
- Assert that the submit button is not longer disabled and that it is possible to proceed with the correct code once an error message is displayed.
- [x] Code
- [x] Product
