### PR TITLE
Framework: Display original source code in development tools

### DIFF
--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -57,7 +57,7 @@ if ( NODE_ENV === 'development' ) {
 	config.debug = true;
 
 	// Enables source maps
-	config.devtool = 'eval';
+	config.devtool = 'cheap-module-eval-source-map';
 }
 
 if ( NODE_ENV === 'production' ) {

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -37,7 +37,7 @@ var config = merge.smart( baseConfig, {
 
 	// Enables source maps
 	// This is fine since the server won't be used in production
-	devtool: 'sourcemap',
+	devtool: 'source-map',
 
 	plugins: [
 		// inject source map support on top of the build file


### PR DESCRIPTION
This pull request updates the Webpack configuration to use a different [source map settings](https://webpack.github.io/docs/configuration.html#devtool) so the original source code is displayed in the browser's development tools - instead of the code transpiled:
##### Before

![previous](https://cloud.githubusercontent.com/assets/594356/16336877/24e5deac-3a11-11e6-9a55-02402a7d1980.png)

```
Client build time: 14835ms
Server build time: 10340ms
```
##### After

![screenshot](https://cloud.githubusercontent.com/assets/594356/16336916/aec6396e-3a11-11e6-9187-eec598938bcf.png)

```
Client build time: 16071ms
Server build time: 10809ms
```
#### Testing instructions
1. Run `git checkout add/better-source-maps` and start your server, or open a [live branch](https://delphin.live/?branch=add/better-source-maps)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that you can now see the original code in your browser development tools
#### Additional notes

Calypso recently [updated this setting](https://github.com/Automattic/wp-calypso/pull/5656) but also introduced the `source-map-loader` Webpack loader. The [documentation](https://webpack.github.io/docs/configuration.html#devtool) mentions the following however I couldn't find why we would need that:

> Hint: If your modules already contain SourceMaps you’ll need to use the source-map-loader to merge it with the emitted SourceMap.
#### Reviews
- [ ] Code

@Automattic/sdev-feed
