### PR TITLE
Fix resources not loading because quotes are escaped when CSS is rendered server-side

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -74,7 +74,7 @@ rules:
   pseudo-element: 1
   quotes: 1
   shorthand-values: 1
-  url-quotes: 1
+  url-quotes: 0
   variable-for-property: 1
   zero-unit: 1
 

--- a/app/components/ui/header/styles.scss
+++ b/app/components/ui/header/styles.scss
@@ -1,6 +1,6 @@
 %header {
 	align-items: center;
-	background: url( 'http://s.wordpress.com/i/delphin/background.png' ) center top #87a6bc;
+	background: url( http://s.wordpress.com/i/delphin/background.png ) center top #87a6bc;
 	box-shadow: 0 -10px 10px -10px rgba(0, 0, 0, 0.3) inset;
 	display: flex;
 	justify-content: space-between;

--- a/app/components/ui/host-info/styles.scss
+++ b/app/components/ui/host-info/styles.scss
@@ -38,17 +38,17 @@
 	width: 250px;
 
 	&.wordpress {
-		background: url( '/images/hosts/wordpress-horizontal.svg' ) no-repeat center center;
+		background: url( /images/hosts/wordpress-horizontal.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.medium {
-		background: url( '/images/hosts/medium-horizontal.svg' ) no-repeat center center;
+		background: url( /images/hosts/medium-horizontal.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.tumblr {
-		background: url( '/images/hosts/tumblr-horizontal.svg' ) no-repeat center center;
+		background: url( /images/hosts/tumblr-horizontal.svg ) no-repeat center center;
 		background-size: contain;
 	}
 }

--- a/app/components/ui/hosts/styles.scss
+++ b/app/components/ui/hosts/styles.scss
@@ -9,7 +9,7 @@ $thumb-horizontal-margin: 15px;
 
 .heading2 {
 	color: #2e4453;
-	font-family: 'Merriweather', serif;
+	font-family: Merriweather, serif;
 	font-size: 2.6rem;
 	font-weight: 600;
 	text-align: center;
@@ -104,17 +104,17 @@ $thumb-horizontal-margin: 15px;
 	width: 150px;
 
 	&.wordpress {
-		background: url( '/images/hosts/wordpress-small.svg' ) no-repeat center center;
+		background: url( /images/hosts/wordpress-small.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.medium {
-		background: url( '/images/hosts/medium-small.svg' ) no-repeat center center;
+		background: url( /images/hosts/medium-small.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.tumblr {
-		background: url( '/images/hosts/tumblr-small.svg' ) no-repeat center center;
+		background: url( /images/hosts/tumblr-small.svg ) no-repeat center center;
 		background-size: contain;
 	}
 }

--- a/app/components/ui/search-input/styles.scss
+++ b/app/components/ui/search-input/styles.scss
@@ -53,11 +53,11 @@
 }
 
 .keyword-delete {
-	background: url( 'http://s.wordpress.com/i/delphin/trash.svg' ) center no-repeat $dark-gray-blue;
+	background: url( http://s.wordpress.com/i/delphin/trash.svg ) center no-repeat $dark-gray-blue;
 }
 
 .keyword-select {
-	background: url( 'http://s.wordpress.com/i/delphin/right-arrow.svg' ) center no-repeat $dark-gray-blue;
+	background: url( http://s.wordpress.com/i/delphin/right-arrow.svg ) center no-repeat $dark-gray-blue;
 }
 
 .keyword-hidden {
@@ -122,5 +122,5 @@
 }
 
 .is-google-translate-attribution-visible {
-	background: $white url( '/images/powered-by-google-translate.png' ) no-repeat bottom right;
+	background: $white url( /images/powered-by-google-translate.png ) no-repeat bottom right;
 }

--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -92,7 +92,7 @@
 
 .sort-select {
 	appearance: none;
-	background: url( 'http://s.wordpress.com/i/delphin/form-ui-select.png' ) no-repeat right center;
+	background: url( http://s.wordpress.com/i/delphin/form-ui-select.png ) no-repeat right center;
 	background-size: 50px 63px;
 	font-size: 1.8rem;
 	height: 61px;


### PR DESCRIPTION
This pull request is a follow-up of #214 that disables the linting rule that makes sure that urls are wrapped in quotes. This is indeed a problem because these quotes are escaped when stylesheets are rendered server-side, which leads to resources such as the background image not loading:

![screenshot](https://cloud.githubusercontent.com/assets/594356/16339586/ccb62422-3a23-11e6-99eb-d78fede20257.png)
#### Testing instructions
1. Run `git checkout fix/quotes-escaped` and start your server, or open a [live branch](https://delphin.live/?branch=fix/quotes-escaped)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that the background image in the header loads without bumps
4. Check that there is no 404 error in your browser's console
#### Additional notes

It would have been great to have the opposite rule that ensures we actually don't use quotes.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
