### PR TITLE
Brought up a library to help with auto-binding when extending React.Component

### DIFF
--- a/app/components/ui/search-input/index.js
+++ b/app/components/ui/search-input/index.js
@@ -4,6 +4,7 @@ import intersection from 'lodash/intersection';
 import React, { PropTypes } from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import { bindHandlers } from 'react-bind-handlers';
 
 // Internal dependencies
 import styles from './styles.scss';
@@ -11,14 +12,6 @@ import KeywordsContainer from 'components/containers/keywords';
 import RelatedWords from './related-words';
 
 class SearchInput extends React.Component {
-	constructor( props ) {
-		super( props );
-
-		this.handleInputKeydownBound = this.handleInputKeydown.bind( this );
-		this.handleInputChangeBound = this.handleInputChange.bind( this );
-		this.handleSubmitBound = this.handleSubmit.bind( this );
-	}
-
 	componentWillReceiveProps( nextProps ) {
 		// sync to url the keywords if they change
 		const keywordValues = this.props.keywords.map( keyword => keyword.value ),
@@ -54,7 +47,7 @@ class SearchInput extends React.Component {
 			relatedWordsForSelectedKeyword = selectedKeyword && find( this.props.relatedWords, { word: selectedKeyword.value } );
 
 		return (
-			<form className={ styles.searchWrapper } onSubmit={ this.handleSubmitBound }>
+			<form className={ styles.searchWrapper } onSubmit={ this.handleSubmit }>
 				<KeywordsContainer />
 				<ReactCSSTransitionGroup
 					transitionName={ styles.relatedWords }
@@ -74,8 +67,8 @@ class SearchInput extends React.Component {
 					className="search"
 					value={ this.props.inputValue }
 					placeholder={ this.props.placeholder }
-					onChange={ this.handleInputChangeBound }
-					onKeyDown={ this.handleInputKeydownBound }
+					onChange={ this.handleInputChange }
+					onKeyDown={ this.handleInputKeydown }
 				/>
 			</form>
 		);
@@ -100,4 +93,4 @@ SearchInput.propTypes = {
 	submit: PropTypes.func.isRequired
 };
 
-export default withStyles( styles )( SearchInput );
+export default withStyles( styles )( bindHandlers( SearchInput ) );

--- a/app/components/ui/search-input/keyword.js
+++ b/app/components/ui/search-input/keyword.js
@@ -2,26 +2,20 @@
 import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import { bindHandlers } from 'react-bind-handlers';
 
 // Internal dependencies
 import { isDomain } from 'lib/domains';
 import styles from './styles.scss';
 
 class Keyword extends React.Component {
-	constructor( props ) {
-		super( props );
-
-		this.onRemoveClickBound = this.onRemoveClick.bind( this );
-		this.onKeywordClickBound = this.onKeywordClick.bind( this );
-	}
-
-	onRemoveClick( event ) {
+	handleRemoveClick( event ) {
 		this.props.remove( this.props.keyword );
 
 		event.stopPropagation();
 	}
 
-	onKeywordClick() {
+	handleKeywordClick() {
 		this.props.toggleSelect( this.props.keyword );
 	}
 
@@ -36,12 +30,12 @@ class Keyword extends React.Component {
 		return (
 			<li
 				className={ keywordClassName }
-				onClick={ this.onKeywordClickBound }>
+				onClick={ this.handleKeywordClick }>
 				{ keyword.value }
 				{ keyword.isSelected && (
 					<span
 						className={ styles.keywordAction + ' ' + styles.keywordDelete }
-						onClick={ this.onRemoveClickBound } />
+						onClick={ this.handleRemoveClick } />
 				) }
 				{ ! keyword.isSelected && ! keywordIsDomain && (
 					<span className={ styles.keywordAction + ' ' + styles.keywordSelect } />
@@ -60,4 +54,4 @@ Keyword.propTypes = {
 	toggleSelect: PropTypes.func.isRequired
 };
 
-export default withStyles( styles )( Keyword );
+export default withStyles( styles )( bindHandlers( Keyword ) );

--- a/app/components/ui/search-input/related-word.js
+++ b/app/components/ui/search-input/related-word.js
@@ -1,24 +1,19 @@
 // External dependencies
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import { bindHandlers } from 'react-bind-handlers';
 
 // Internal dependencies
 import styles from './styles.scss';
 
 class RelatedWord extends React.Component {
-	constructor( props ) {
-		super( props );
-
-		this.onClickBound = this.onClick.bind( this );
-	}
-
-	onClick() {
+	handleClick() {
 		this.props.onClick( this.props.word );
 	}
 
 	render() {
 		const { word } = this.props;
-		return <li className={ styles.relatedWordsListItem } onClick={ this.onClickBound }>{ word }</li>;
+		return <li className={ styles.relatedWordsListItem } onClick={ this.handleClick }>{ word }</li>;
 	}
 }
 
@@ -27,4 +22,4 @@ RelatedWord.propTypes = {
 	word: PropTypes.string.isRequired
 };
 
-export default withStyles( styles )( RelatedWord );
+export default withStyles( styles )( bindHandlers( RelatedWord ) );

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react": "^15.0.2",
     "react-addons-create-fragment": "^15.0.2",
     "react-addons-css-transition-group": "^15.0.2",
+    "react-bind-handlers": "^1.0.5",
     "react-dom": "^15.0.2",
     "react-hot-loader": "^1.3.0",
     "react-redux": "^4.4.1",


### PR DESCRIPTION
Modified search-input to use the auto-binding for method that start with handle

This pull request replaces #220
#### Testing instructions
1. Run `git checkout update/bind-handlers` and start your server, or open a [live branch](https://delphin.live/?branch=update/bind-handlers)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Use the search feature
4. Verify it works as expected
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
