### PR TITLE
Add a robots.txt file

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This pull request fixes #251 by adding a robots.txt file to stop search engines crawling delphin.
#### Testing instructions
1. Run `git checkout add/robots` and start your server, or open a [live branch](https://delphin.live/?branch=add/robots])
2. Open the http://delphin.localhost:1337/robots.txt
3. Check that the robots.txt file is shown.
#### Additional notes

I'm not sure this going to work on getdotblog.com or do we need to move the file somewhere when we build the static assets? I think we'll need to update the NGINX config too...

This work work for a8cdelphin.wordpress.com - we'll need to check the site visibility settings there.
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
