### PR TITLE
Update stepped progress bar styles

### DIFF
--- a/app/components/ui/checkout-progressbar/styles.scss
+++ b/app/components/ui/checkout-progressbar/styles.scss
@@ -3,9 +3,9 @@
 $step-inner-dot-size: 14px;
 $step-dot-size: 30px;
 $step-line-size: 8px;
-$inactive-step-color: $blue-light;
-$active-step-color: #c8d7e1;
-$inner-dot-color: $gray-blue;
+$inactive-step-color: desaturate( $dark-gray-blue, 15% );
+$active-step-color: $green;
+$inner-dot-color: $blue-background;
 
 .progressbar {
 	display: flex;
@@ -83,6 +83,10 @@ $inner-dot-color: $gray-blue;
 			width: 0;
 		}
 	}
+
+	.progressbar-step-caption {
+		color: $active-step-color;
+	}
 }
 
 @mixin dot-styles( $size, $color ) {
@@ -99,7 +103,7 @@ $inner-dot-color: $gray-blue;
 }
 
 .progressbar-step-caption {
-	color: $inner-dot-color;
+	color: lighten( $inactive-step-color, 10% );
 	font-size: 1.3rem;
 	text-align: center;
 	text-transform: uppercase;


### PR DESCRIPTION
This updates the stepped progress bar styles shown during the signup and checkout flow.

| Before | After |
| --- | --- |
| <img width="422" alt="screen shot 2016-07-01 at 13 22 53" src="https://cloud.githubusercontent.com/assets/448298/16529251/cfd5ceac-3f8f-11e6-9cdf-a5a75283e636.png"> | <img width="410" alt="screen shot 2016-07-01 at 13 24 49" src="https://cloud.githubusercontent.com/assets/448298/16529254/d41d33ec-3f8f-11e6-8c1d-1eafb975ad90.png"> |
