### PR TITLE
Show delphin.localhost when dev server starts

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -170,7 +170,7 @@ const init = () => {
 		} );
 
 		devServer.listen( port, error => {
-			console.log( error || 'Server listening on http://localhost:' + port );
+			console.log( error || 'Server listening on http://delphin.localhost:' + port );
 		} );
 
 		app.listen( backendPort, 'localhost', error => {


### PR DESCRIPTION
`delphin.localhost` is whitelisted on public-api.wordpress.com, without it API requests fail.

@Automattic/sdev-feed 
