### PR TITLE
Checkout: Fix privacy protection not sent to API endpoint

### DIFF
--- a/app/actions/checkout.js
+++ b/app/actions/checkout.js
@@ -92,10 +92,13 @@ export function createTransaction() {
 		const checkout = getCheckout( getState() ),
 			{ domain } = checkout.selectedDomain,
 			contactInformationForm = getValues( getState().form.contactInformation ),
+			checkoutForm = getValues( getState().form.checkout ),
+			{ privacyProtection } = checkoutForm,
 			paygateToken = checkout.paygateToken.data.token;
 
 		const payload = {
 			domain,
+			privacy: privacyProtection,
 			payment_key: paygateToken,
 			payment_method: 'WPCOM_Billing_MoneyPress_Paygate',
 			locale: 'en',


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/delphin/issues/269 to allow users to disable privacy protection when they purchase a domain on the `Checkout` page (previously the button wouldn't have any effect):

![screenshot](https://cloud.githubusercontent.com/assets/594356/16840609/e82fad24-49d5-11e6-9d5a-16fb7d2c4732.png)
#### Testing instructions

It's not possible to register a domain yet but we can check that we send the right information to the API:
1. Run `git checkout fix/privacy-protection` and start your server, or open a [live branch](https://delphin.live/?branch=fix/privacy-protection)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Search a domain and proceed until the `Checkout` page
4. Open the network tab in the developer tools in your browser
5. Click the `Checkout` button
6. Check that the `delphin/transactions` API endpoint is called with `privacy` set to `true`
7. Toggle the `Privacy Protection` button to disable it
8. Click the `Checkout` button again
9. Check that the `delphin/transactions` API endpoint is called with `privacy` set to `false`
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
