### PR TITLE
Use new delphin endpoint for domains suggestions

### DIFF
--- a/app/actions/domain-search.js
+++ b/app/actions/domain-search.js
@@ -19,8 +19,6 @@ import {
 } from 'reducers/action-types';
 import { omitTld } from 'lib/domains';
 
-const availableTLDs = config( 'available_tlds' );
-
 /**
  * Returns an action object to be used in signalling that domain suggestions have been cleared.
  *
@@ -48,10 +46,7 @@ export function fetchDomainSuggestions( domainQuery = '' ) {
 		},
 		query: {
 			query: queryWithoutTlds,
-			quantity: 36,
-			include_wordpressdotcom: false,
-			vendor: 'domainsbot',
-			tlds: availableTLDs
+			quantity: 36
 		},
 		loading: () => ( { type: DOMAIN_SUGGESTIONS_FETCH, query: domainQuery } ),
 		success: ( results ) => ( {


### PR DESCRIPTION
Requires D2364
### Testing Instructions
- Apply the patch on your sandbox
- Go to http://delphin.localhost:1337/search and enter a domain
- Assert that the new endpoint is called (in devtools) and that the new domains have a default price of $30
- Enter the domain name `qwedsa.live` and assert that it has a price of $43244
### Reviews
- [x] Code
- [x] Product
