### PR TITLE
Review application screen: update copy

### DIFF
--- a/app/components/ui/sunrise-confirm-domain/index.js
+++ b/app/components/ui/sunrise-confirm-domain/index.js
@@ -52,7 +52,7 @@ class SunriseConfirmDomain extends React.Component {
 					</h3>
 					<hr className={ styles.rule } />
 					<div className={ styles.priceTag }>
-						{ i18n.translate( '$250 Early application' ) }
+						{ i18n.translate( '$250 Early Application' ) }
 					</div>
 					<div className={ styles.renewalInfo }>
 						{ i18n.translate( '$30 registration + $220 application fee' ) }


### PR DESCRIPTION
Updating the copy on the review application / found it screen:
- Shorter and more straightforward and action-oriented header text.
- Change "application fee" to "one time fee", so there's no confusion about paying for the application separately from the domain.
- Shorter and hopefully clearer footer text about the auction.

![ranimac3 screenshot 2016-07-28 at 13 16 48](https://cloud.githubusercontent.com/assets/426518/17209407/8ee7e7e0-54c5-11e6-9469-6f147363ef9c.png)
- [x] code
- [x] design
