### PR TITLE
Upgrade i18n-calypso

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "http-auth": "^2.3.1",
-    "i18n-calypso": "1.0.8",
+    "i18n-calypso": "1.5.0",
     "inherits": "^2.0.1",
     "isomorphic-style-loader": "^1.0.0",
     "jed": "1.0.2",


### PR DESCRIPTION
This upgrade i18n-calypso to account for a fix in the POT generation (headers didn't end with a \n as defined in the specs see https://github.com/Automattic/i18n-calypso/pull/11).
### Testing Instructions
- Checkout this branch
- Run `npm install`
- Run `npm run translate`
- Check that the generated pot file in `server/build/delphin.pot` is valid
### Reviews
- [ ] Product
