### PR TITLE
Checkout review: explain that payment gets refunded if auction is lost

### DIFF
--- a/app/components/ui/checkout-review/index.js
+++ b/app/components/ui/checkout-review/index.js
@@ -84,7 +84,7 @@ class CheckoutReview extends React.Component {
 				</h1>
 				<h2>
 					{ i18n.translate( 'Applying does not guarantee you get the domain. ' +
-				 	'If others apply for it, you will be able to bid for it in an auction.' ) }
+					'If others apply for it, you will be able to bid for it in an auction.' ) }
 				</h2>
 			</SunriseStep.Header>
 


### PR DESCRIPTION
Add language to the checkout review screen to explain that the payment gets refund if the applicant ends up losing in an auction.

![ranimac3 screenshot 2016-08-01 at 21 24 00](https://cloud.githubusercontent.com/assets/426518/17304446/4927218c-582e-11e6-9c54-2f3f0c7408b4.png)
- [x] code
- [ ] copy
