### PR TITLE
Analytics: Adding a launch_period to analytics super props

### DIFF
--- a/app/lib/analytics/index.js
+++ b/app/lib/analytics/index.js
@@ -77,20 +77,8 @@ window.addEventListener( 'popstate', function() {
 const analytics = {
 	user: null,
 
-	superProps: null,
-
-	initialize( user, superProps ) {
-		analytics.setUser( user );
-		analytics.setSuperProps( superProps );
-		analytics.identifyUser();
-	},
-
-	setUser( { id, username } ) {
-		this.user = { id, username };
-	},
-
-	setSuperProps( superProps ) {
-		this.superProps = superProps;
+	superProps: {
+		launch_period: 'landrush pre-reg' // Future options will be landrush and ga
 	},
 
 	mc: {
@@ -274,21 +262,6 @@ const analytics = {
 
 			window.ga( 'send', 'timing', urlPath, eventType, duration, triggerName );
 		}
-	},
-
-	identifyUser() {
-		// Don't identify the user if we don't have one
-		if ( this.user ) {
-			window._tkq.push( [ 'identifyUser', this.user.id, this.user.username ] );
-		}
-	},
-
-	setProperties( properties ) {
-		window._tkq.push( [ 'setProperties', properties ] );
-	},
-
-	clearedIdentity() {
-		window._tkq.push( [ 'clearIdentity' ] );
 	}
 };
 


### PR DESCRIPTION
This pull request fixes #318 by adding a `launch_period` property to the tracks events in Delphin.
#### Testing instructions
1. Run `git checkout add/super-props` and start your server, or open a [live branch](https://delphin.live/?branch=add/super-props)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Execute localStorage.setItem('debug', 'delphin:analytics') in your browser's console
4. Check that when the page view analytics event is fired it also contains the `launch_period` property
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
