### PR TITLE
Send a `_locale` param to the v2 API

### DIFF
--- a/client/wpcom-middleware/index.js
+++ b/client/wpcom-middleware/index.js
@@ -25,14 +25,21 @@ const UNAUTHENTICATED_NAMESPACES = [ 'geo/' ];
  *
  * @param  {String} locale the requested locale
  * @param  {Object} query Original query parameters
+ * @param  {String} apiNamespace The namespace of the request
  * @return {Object}        Revised parameters, if non-default locale
  */
-function addLocaleQueryParam( locale, query ) {
-	if ( ! locale || 'en' === locale ) {
-		return query;
+function addLocaleQueryParam( locale, query, apiNamespace ) {
+	let localeParam;
+
+	if ( apiNamespace === 'wpcom/v2' ) {
+		// Meta properties like locale are prefixed with an underscore in the
+		// v2 API
+		localeParam = { _locale: locale };
+	} else {
+		localeParam = { locale };
 	}
 
-	return Object.assign( {}, query, { locale } );
+	return Object.assign( {}, query, localeParam );
 }
 
 /**
@@ -85,7 +92,7 @@ function makeWpcomRequest( state, action ) {
 		} );
 	}
 
-	query = query ? addLocaleQueryParam( locale, query ) : { locale };
+	query = addLocaleQueryParam( locale, query || {}, params.apiNamespace );
 
 	const reqArgs = [ params, query ];
 

--- a/client/wpcom-middleware/tests/middleware.js
+++ b/client/wpcom-middleware/tests/middleware.js
@@ -92,6 +92,31 @@ describe( 'wpcom-middleware', () => {
 			expect( WPCOM().req[ method ] ).lastCalledWith( params, { locale: 'fr' }, payload );
 		} );
 
+		it( 'should make a request with the `_locale` property if using the v2 API namespace', () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'ja' }
+			} );
+
+			const store = {
+				getState: jest.genMockFunction().mockReturnValue( {} ),
+				dispatch: jest.genMockFunction()
+			};
+
+			const paramsWithNamespace = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
+
+			middleware( store )( () => {} )( {
+				type: WPCOM_REQUEST,
+				method,
+				params: paramsWithNamespace,
+				payload,
+				loading: LOADING_ACTION,
+				success: SUCCESS_ACTION,
+				fail: FAIL_ACTION
+			} );
+
+			expect( WPCOM().req[ method ] ).lastCalledWith( paramsWithNamespace, { _locale: 'ja' }, payload );
+		} );
+
 		it( 'should make a request with the locale of the user if present', () => {
 			const store = {
 				getState: jest.genMockFunction().mockReturnValue( {


### PR DESCRIPTION
For use with D2421-code.

v2 API endpoints use the `_locale` slug instead of `locale`. This PR updates `wpcom-middleware` to include the `_locale` param if the namespace is set to `wpcom/v2`.

**Testing**
I added a test for this case, but the actual testing instructions pertain mostly to the behavior of the API so I left them on the aforementioned patch.
- [x] Code
- [ ] Product
