### PR TITLE
Set a `locale` cookie when the page boots

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -18,6 +18,7 @@ import { fetchUser } from 'actions/user';
 import { getTokenFromBearerCookie } from './bearer-cookie';
 import reducers from 'reducers';
 import i18n from 'i18n-calypso';
+import { setLocaleCookie } from './locale-cookie';
 import Stylizer, { insertCss } from 'lib/stylizer';
 import switchLocale from './switch-locale';
 import { userMiddleware } from './user-middleware';
@@ -95,6 +96,8 @@ function boot() {
 	i18n.stateObserver.on( 'change', render );
 
 	window.switchLocale = switchLocale;
+
+	setLocaleCookie( i18n.getLocaleSlug() );
 }
 
 boot();

--- a/client/locale-cookie/index.js
+++ b/client/locale-cookie/index.js
@@ -1,0 +1,9 @@
+// External dependencies
+import cookieFactory from 'cookie-dough';
+
+const cookies = cookieFactory();
+
+export const setLocaleCookie = locale => cookies.set( 'locale', locale, {
+	maxAge: 30 * 24 * 60 * 60,
+	path: '/'
+} );


### PR DESCRIPTION
This is necessary to redirect the user to their desired locale.
- Users that visit `/` will be redirected to `/:locale` depending on their cookie or browser setting if no cookie is set.
- Users that visit `/:locale` will not be redirected anywhere, regardless of browser setting or their locale cookie. This will allow the language picker to just redirect the user to `/:locale`.

`getdotblog.com` does everything except respect the cookie right now. D2423-code will add this behavior. In the mean time, this simple PR can be reviewed.

**Testing**
- Visit `/`.
- Open the console.
- Assert that `document.cookie` contains `locale=en`.
- Visit `/fr`.
- Open the console.
- Assert that `document.cookie` contains `locale=fr`.
- [x] Code
- [x] Product
