### PR TITLE
Copy: Code screen: Change "two factor" to "two-step" (to match wpcom)

### DIFF
--- a/app/components/ui/connect-user/verify-user/index.js
+++ b/app/components/ui/connect-user/verify-user/index.js
@@ -116,7 +116,7 @@ const VerifyUser = React.createClass( {
 		if ( user.data.twoFactorAuthenticationEnabled ) {
 			return (
 				<div className={ styles.twoFactorFields }>
-					<label>{ i18n.translate( 'Two factor authentication code:' ) }</label>
+					<label>{ i18n.translate( 'Two-step authentication code:' ) }</label>
 
 					<Input
 						field={ fields.twoFactorAuthenticationCode }


### PR DESCRIPTION
WordPress.com users "two-step authentication" in the app and in support docs. This changes one use of "two factor" to "two-step" to match WordPress.com.
- [x] code
