### PR TITLE
Landing Page: Fix design inconsistencies

### DIFF
--- a/app/components/ui/domain-input/styles.scss
+++ b/app/components/ui/domain-input/styles.scss
@@ -40,6 +40,7 @@
 		border-bottom-right-radius: 0;
 		border-top-right-radius: 0;
 		line-height: 34px;
+		margin: 0;
 	}
 }
 

--- a/app/components/ui/sunrise-home/styles.scss
+++ b/app/components/ui/sunrise-home/styles.scss
@@ -40,7 +40,7 @@
 .domain-search {
 	align-items: flex-start;
 	display: flex;
-	font-size: 1.6rem;
+	font-size: 1.4rem;
 	margin: 0 auto 6em;
 	max-width: 550px;
 
@@ -69,6 +69,7 @@
 		box-sizing: border-box;
 		color: $blue-dark;
 		font-family: $body-font;
+		font-size: 1.6rem;
 		padding: 10px 16px;
 		transition: background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out, color .15s ease-in-out;
 		width: 100%;
@@ -76,10 +77,6 @@
 		&:focus {
 			box-shadow: none;
 			outline: none;
-		}
-
-		@include breakpoint( '>660px' ) {
-			font-size: 1.8rem;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes #386 and some other design consistencies mentioned in #374. Specifically:
- `.blog` extension suffix height
- inline validation error font-size
- input font-size

| Before | After |
| --- | --- |
| <img width="576" alt="screen shot 2016-08-04 at 16 43 09" src="https://cloud.githubusercontent.com/assets/448298/17417685/8e9bf72a-5a62-11e6-8173-5b42cfb327a4.png"> | <img width="582" alt="screen shot 2016-08-04 at 16 40 38" src="https://cloud.githubusercontent.com/assets/448298/17417612/3668ef04-5a62-11e6-94b9-c4559c791af6.png"> |

**Review**
- [x] Product
- [x] Code
