### PR TITLE
Wrap long domain names to second line

### DIFF
--- a/app/components/ui/checkout-review/styles.scss
+++ b/app/components/ui/checkout-review/styles.scss
@@ -47,6 +47,7 @@
 .domain {
 	color: $blue-background;
 	font-size: 2rem;
+	word-wrap: break-word;
 }
 
 .application-fee {

--- a/app/components/ui/contact-information/styles.scss
+++ b/app/components/ui/contact-information/styles.scss
@@ -23,6 +23,10 @@
 	line-height: 1.4;
 	margin-top: 10px;
 
+	strong {
+		word-wrap: break-word;
+	}
+
 	@include breakpoint( '<480px' ) {
 		font-size: 1.8rem;
 	}

--- a/app/components/ui/sunrise-step/form/styles.scss
+++ b/app/components/ui/sunrise-step/form/styles.scss
@@ -19,6 +19,7 @@
 	h3 {
 		color: $blue-dark;
 		font-size: 2rem;
+		word-wrap: break-word;
 	}
 
 	hr {


### PR DESCRIPTION
This fixes #387 everywhere we display the domain name.

| Before | After |
| --- | --- |
| <img width="470" alt="screen shot 2016-08-04 at 16 49 02" src="https://cloud.githubusercontent.com/assets/448298/17418134/e0be46c8-5a64-11e6-990b-62e774cca679.png"> | <img width="470" alt="screen shot 2016-08-04 at 16 53 17" src="https://cloud.githubusercontent.com/assets/448298/17418130/dcdf423c-5a64-11e6-9cc2-6479cefd0f7c.png"> |
| <img width="503" alt="screen shot 2016-08-04 at 16 53 54" src="https://cloud.githubusercontent.com/assets/448298/17418139/e57e89de-5a64-11e6-9542-b24326eb039a.png"> | <img width="503" alt="screen shot 2016-08-04 at 16 54 32" src="https://cloud.githubusercontent.com/assets/448298/17418141/e880c6ce-5a64-11e6-9d24-cb5d32152c5b.png"> |
| <img width="474" alt="screen shot 2016-08-04 at 16 55 39" src="https://cloud.githubusercontent.com/assets/448298/17418147/ed6333f2-5a64-11e6-8cf3-5290428b8c14.png"> | <img width="468" alt="screen shot 2016-08-04 at 16 56 44" src="https://cloud.githubusercontent.com/assets/448298/17418152/f0b88a3e-5a64-11e6-8ffb-7cf59f4964d6.png"> |

**Review**
- [x] Product
- [x] Code
