### PR TITLE
Framework: Fix thin font readability issues in Safari

### DIFF
--- a/app/components/ui/sunrise-confirm-domain/styles.scss
+++ b/app/components/ui/sunrise-confirm-domain/styles.scss
@@ -15,7 +15,6 @@
 
 .button {
 	font-size: 1.5rem;
-	font-weight: 200;
 	margin-bottom: 20px;
 	margin-top: 30px;
 	padding: 18px 0;

--- a/app/components/ui/sunrise-home/styles.scss
+++ b/app/components/ui/sunrise-home/styles.scss
@@ -24,7 +24,7 @@
 
 .secondary-heading {
 	font-size: 2.2rem;
-	font-weight: 200;
+	font-weight: 300;
 
 	@include breakpoint( '<480px' ) {
 		font-size: 1.8rem;

--- a/app/components/ui/sunrise-step/header/styles.scss
+++ b/app/components/ui/sunrise-step/header/styles.scss
@@ -28,7 +28,7 @@
 	h2 {
 		font-family: $body-font;
 		font-size: 2rem;
-		font-weight: 200;
+		font-weight: 300;
 		line-height: 1.4;
 		margin-top: 10px;
 

--- a/app/components/ui/sunrise-step/styles.scss
+++ b/app/components/ui/sunrise-step/styles.scss
@@ -2,5 +2,5 @@
 
 .sunrise-step {
 	font-size: 1.4rem;
-	font-weight: 200;
+	font-weight: 300;
 }


### PR DESCRIPTION
This fixes #381 by removing `font-weight: 200` everywhere.

Apparently, Lato does not even have a `font-weight: 200` as referenced [here](https://www.google.com/fonts/specimen/Lato). It seems Safari was using `100` and Chrome and Firefox were using `300`. That's why there was a display disparity between browsers. Changing font weight to use 300 instead of 200 confirmed no visual difference in Chrome and Firefox.

| Before | After |
| --- | --- |
| <img width="522" alt="screen shot 2016-08-04 at 17 29 27" src="https://cloud.githubusercontent.com/assets/448298/17418941/05be51bc-5a69-11e6-84b2-07f7c5671ab4.png"> | <img width="541" alt="screen shot 2016-08-04 at 17 28 58" src="https://cloud.githubusercontent.com/assets/448298/17418930/f512f264-5a68-11e6-9eb8-77b0d8f8cca3.png"> |

Tested in Chrome, Safari, and Firefox on Mac OS X. We should test in other environments including IE, Windows, Linux, non-retina, etc.
