### PR TITLE
Fix more design inconsistencies

### DIFF
--- a/app/components/ui/connect-user/header/styles.scss
+++ b/app/components/ui/connect-user/header/styles.scss
@@ -16,9 +16,11 @@
 .heading {
 	font-family: $heading-font;
 	font-size: 3rem;
+	margin-top: 40px;
 
 	@include breakpoint( '<480px' ) {
 		font-size: 2.6rem;
+		margin-top: 0;
 	}
 }
 

--- a/app/components/ui/sunrise-confirm-domain/styles.scss
+++ b/app/components/ui/sunrise-confirm-domain/styles.scss
@@ -14,7 +14,6 @@
 }
 
 .button {
-	font-size: 1.5rem;
 	margin-bottom: 20px;
 	margin-top: 30px;
 	padding: 18px 0;


### PR DESCRIPTION
Fix more inconsistencies in #374 
- "Apply for this domain" button
- Headline margin

| Before | After |
| --- | --- |
| <img width="506" alt="screen shot 2016-08-04 at 17 48 10" src="https://cloud.githubusercontent.com/assets/448298/17419518/d57adfcc-5a6b-11e6-84de-b711c859737f.png"> | <img width="543" alt="screen shot 2016-08-04 at 17 47 27" src="https://cloud.githubusercontent.com/assets/448298/17419522/dafab3d2-5a6b-11e6-9f83-cd88af5d28ab.png"> |
