### PR TITLE
Move NameJet string to a variable for i18n

### DIFF
--- a/app/components/ui/success/index.js
+++ b/app/components/ui/success/index.js
@@ -9,6 +9,8 @@ import styles from './styles.scss';
 import SunriseStep from 'components/ui/sunrise-step';
 import withPageView from 'lib/analytics/with-page-view';
 
+const auctionPartnerName = 'NameJet';
+
 const Success = ( { domain, email, trackAuctionSignup } ) => (
 	<SunriseStep className={ styles.step }>
 		<DocumentTitle title={ i18n.translate( 'Success' ) } />
@@ -54,7 +56,11 @@ const Success = ( { domain, email, trackAuctionSignup } ) => (
 				</p>
 
 				<p>
-					{ i18n.translate( 'Please set up an account with our auction partner, NameJet, so you will be ready in case your domain goes to auction.' ) }
+					{ i18n.translate( 'Please set up an account with our auction partner, %(auctionPartnerName)s, so you will be ready in case your domain goes to auction.', {
+						args: {
+							auctionPartnerName
+						}
+					} ) }
 				</p>
 
 				<a
@@ -62,7 +68,11 @@ const Success = ( { domain, email, trackAuctionSignup } ) => (
 					href="https://www.namejet.com/Pages/Login.aspx"
 					onClick={ trackAuctionSignup }
 					target="_blank">
-					{ i18n.translate( 'Sign up at NameJet' ) }
+					{ i18n.translate( 'Sign up at %(auctionPartnerName)s', {
+						args: {
+							auctionPartnerName
+						}
+					} ) }
 				</a>
 			</div>
 		</div>


### PR DESCRIPTION
This pull request fixes #406 by making NameJet a variable.
#### Testing instructions
1. Run `git checkout update/namejet` and start your server, or open a [live branch](https://delphin.live/?branch=update/namejet)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Go through checkout flow until you are on the success page.
4. Assert that you can still see the "NameJet" string.
#### Additional notes

To double check you could open `app/components/ui/success/index.js` in your text editor and change the string NameJet to something else. It should update in your browser in real time if you are testing locally.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
