### PR TITLE
Update site title to get.blog

### DIFF
--- a/app/components/ui/document-title/index.js
+++ b/app/components/ui/document-title/index.js
@@ -2,7 +2,7 @@
 import DocumentTitle from 'react-document-title';
 import React, { PropTypes } from 'react';
 
-const DEFAULT_TITLE = 'MagicDomains';
+const DEFAULT_TITLE = 'get.blog';
 
 const DocumentTitleWrapper = ( { children, title } ) => {
 	const formattedTitle = title ? `${ title } | ${ DEFAULT_TITLE }` : DEFAULT_TITLE;


### PR DESCRIPTION
This pull request fixes #399 by changing the site title to get.blog
#### Testing instructions
1. Run `git checkout update/site-title` and start your server, or open a [live branch](https://delphin.live/?branch=update/site-title)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that the site title is get.blog
#### Additional notes

[...]
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
