### PR TITLE
Update images to use the CDN

### DIFF
--- a/app/components/ui/checkout-review/styles.scss
+++ b/app/components/ui/checkout-review/styles.scss
@@ -63,7 +63,7 @@
 }
 
 .refund-notice {
-	background: url( /images/happy-surprise.svg ) no-repeat right 15px;
+	background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/happy-surprise.svg ) no-repeat right 15px;
 	color: $gray-dark;
 	font-size: 1.4rem;
 	padding: 15px 40px 0 0;

--- a/app/components/ui/header/index.js
+++ b/app/components/ui/header/index.js
@@ -11,7 +11,7 @@ const Header = () => {
 	return (
 		<header className={ styles.header }>
 			<Link className={ styles.logo } to={ getPath( 'home' ) }>
-				<img alt="get.blog" src="/images/get-dot-blog-logo.svg" />
+				<img alt="get.blog" src="https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/get-dot-blog-logo.svg" />
 			</Link>
 		</header>
 	);

--- a/app/components/ui/host-info/styles.scss
+++ b/app/components/ui/host-info/styles.scss
@@ -38,17 +38,17 @@
 	width: 250px;
 
 	&.wordpress {
-		background: url( /images/hosts/wordpress-horizontal.svg ) no-repeat center center;
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/hosts/wordpress-horizontal.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.medium {
-		background: url( /images/hosts/medium-horizontal.svg ) no-repeat center center;
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/hosts/medium-horizontal.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.tumblr {
-		background: url( /images/hosts/tumblr-horizontal.svg ) no-repeat center center;
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/hosts/tumblr-horizontal.svg ) no-repeat center center;
 		background-size: contain;
 	}
 }

--- a/app/components/ui/hosts/host-thumbnail.js
+++ b/app/components/ui/hosts/host-thumbnail.js
@@ -15,7 +15,7 @@ const HostThumbnail = ( { slug, name, shortDescription } ) => (
 		<p className={ styles.thumbnailDescription }>{ shortDescription }</p>
 		<Link className={ styles.thumbnailLearnMore } to={ getPath( 'hostInfo', { slug } ) }>{ i18n.translate( 'Learn More' ) }</Link>
 		<a className={ styles.thumbnailConnect }>
-			<img className={ styles.thumbnailLinkIcon } src="/images/link.svg" />
+			<img className={ styles.thumbnailLinkIcon } src="https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/link.svg" />
 			{ i18n.translate( 'Connect Now' ) }
 		</a>
 	</li>

--- a/app/components/ui/hosts/styles.scss
+++ b/app/components/ui/hosts/styles.scss
@@ -104,17 +104,17 @@ $thumb-horizontal-margin: 15px;
 	width: 150px;
 
 	&.wordpress {
-		background: url( /images/hosts/wordpress-small.svg ) no-repeat center center;
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/hosts/wordpress-small.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.medium {
-		background: url( /images/hosts/medium-small.svg ) no-repeat center center;
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/hosts/medium-small.svg ) no-repeat center center;
 		background-size: contain;
 	}
 
 	&.tumblr {
-		background: url( /images/hosts/tumblr-small.svg ) no-repeat center center;
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/hosts/tumblr-small.svg ) no-repeat center center;
 		background-size: contain;
 	}
 }

--- a/app/components/ui/search-input/styles.scss
+++ b/app/components/ui/search-input/styles.scss
@@ -56,12 +56,12 @@
 }
 
 .keyword-delete {
-	background-image: url( /images/trash.svg );
+	background-image: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/trash.svg );
 	background-size: 12px;
 }
 
 .keyword-select {
-	background-image: url( /images/down-arrow.svg );
+	background-image: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/down-arrow.svg );
 	background-size: 15px;
 	margin: 1px 0 0;
 }

--- a/app/components/ui/search/header.js
+++ b/app/components/ui/search/header.js
@@ -19,7 +19,7 @@ const SearchHeader = ( { query, onQueryChange } ) => {
 				placeholder={ i18n.translate( 'Type a few keywords or an address' ) } />
 
 			<Link className={ styles.logo } to={ getPath( 'home' ) }>
-				<img alt="get.blog" src="/images/get-dot-blog-logo.svg" />
+				<img alt="get.blog" src="https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/get-dot-blog-logo.svg" />
 			</Link>
 		</header>
 	);

--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -107,7 +107,7 @@
 
 .sort-select {
 	appearance: none;
-	background: url( /images/down-arrow.svg ) no-repeat 95% center;
+	background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/down-arrow.svg ) no-repeat 95% center;
 	background-size: 10px;
 	border: 0;
 	border-bottom: 1px solid $white;

--- a/app/components/ui/success/styles.scss
+++ b/app/components/ui/success/styles.scss
@@ -4,7 +4,7 @@
 @import 'app/styles/breakpoints';
 
 .header {
-	background-image: url( /images/smiley-blog.svg );
+	background-image: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/smiley-blog.svg );
 	background-position: center 70px;
 	background-repeat: no-repeat;
 


### PR DESCRIPTION
This pull request fixes #248 by moving all images in Delphin to the CDN
#### Testing instructions
1. Run `git checkout fix/images` and start your server, or open a [live branch](https://delphin.live/?branch=fix/images)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Go through the flow and assert that the following images show:
- [ ] The logo in the header
- [ ] The success page image
- [ ] The happy surprise in checkout review
- [ ] The down arrows and trash can next to keywords in search
- [ ] The images for the list of hosts plus the link icon  (not sure you can get to this right now)
  #### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed 
