### PR TITLE
Success: Column width broken by long strings

### DIFF
--- a/app/components/ui/success/styles.scss
+++ b/app/components/ui/success/styles.scss
@@ -22,7 +22,7 @@
 	font-family: $body-font;
 	font-size: 1.6rem;
 	margin: -40px auto 25px;
-	max-width: 700px;
+	max-width: 800px;
 
 	@include breakpoint( '<660px' ) {
 		flex-direction: column;
@@ -52,6 +52,7 @@
 		border-bottom-left-radius: 5px;
 		border-top-left-radius: 5px;
 		flex-basis: 40%;
+		margin-left: 15px;
 	}
 
 	h3 {
@@ -59,11 +60,17 @@
 		font-size: 2.2rem;
 	}
 
-	p:not(:first-child) {
-		color: $gray-dark;
 
-		@include breakpoint( '<660px' ) {
-			margin-top: 5px;
+
+	p {
+		word-break: break-word;
+
+		&:not(:first-child) {
+			color: $gray-dark;
+
+			@include breakpoint( '<660px' ) {
+				margin-top: 5px;
+			}
 		}
 	}
 }
@@ -76,6 +83,7 @@
 		border-bottom-right-radius: 5px;
 		border-top-right-radius: 5px;
 		flex-basis: 60%;
+		margin-right: 15px;
 	}
 
 	.button {


### PR DESCRIPTION
When a string of text like an email address was wider than the alotted 40% of the left column, the column was stretching beyond 40%. To fix I used `word-break: break-word;`.

Before:

![image](https://cloud.githubusercontent.com/assets/12596797/17446109/c30c6a04-5b15-11e6-957a-505fc5d7229f.png)

After:

<img width="1005" alt="screen shot 2016-08-05 at 1 55 26 pm" src="https://cloud.githubusercontent.com/assets/12596797/17446114/ccabf1c4-5b15-11e6-8f97-e18dff27dc6c.png">
