### PR TITLE
Fix input height, clear field icon, and blue underline alignment

### DIFF
--- a/app/components/ui/domain-input/styles.scss
+++ b/app/components/ui/domain-input/styles.scss
@@ -39,7 +39,6 @@
 	.input {
 		border-bottom-right-radius: 0;
 		border-top-right-radius: 0;
-		line-height: 34px;
 		margin: 0;
 	}
 }

--- a/app/components/ui/form/styles.scss
+++ b/app/components/ui/form/styles.scss
@@ -26,6 +26,13 @@
 	}
 }
 
+input::-ms-clear,
+input::-ms-reveal {
+	display: none;
+	height: 0;
+	width: 0;
+}
+
 .notice-area {
 	background: $gray-light;
 	font-size: 1.6rem;

--- a/app/components/ui/sunrise-confirm-domain/index.js
+++ b/app/components/ui/sunrise-confirm-domain/index.js
@@ -6,6 +6,7 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
 import Button from 'components/ui/button';
+import PartialUnderline from 'components/ui/partial-underline';
 import DocumentTitle from 'components/ui/document-title';
 import { getPath } from 'routes';
 import styles from './styles.scss';
@@ -58,10 +59,10 @@ class SunriseConfirmDomain extends React.Component {
 						</div>
 					) }
 
-					<h3>
-						{ domainName }
-					</h3>
-					<hr className={ styles.rule } />
+					<PartialUnderline className={ styles.domain }>
+						<h3>{ domainName }</h3>
+					</PartialUnderline>
+
 					<div className={ styles.priceTag }>
 						{ i18n.translate( '%(totalCost)s Early Application', {
 							args: { totalCost }

--- a/app/components/ui/sunrise-home/styles.scss
+++ b/app/components/ui/sunrise-home/styles.scss
@@ -70,7 +70,7 @@
 		color: $blue-dark;
 		font-family: $body-font;
 		font-size: 1.6rem;
-		padding: 10px 16px;
+		padding: 18px 16px;
 		transition: background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out, color .15s ease-in-out;
 		width: 100%;
 

--- a/app/components/ui/sunrise-step/form/styles.scss
+++ b/app/components/ui/sunrise-step/form/styles.scss
@@ -21,12 +21,4 @@
 		font-size: 2rem;
 		word-wrap: break-word;
 	}
-
-	hr {
-		background-color: $blue-bright;
-		border: 0;
-		height: 2px;
-		margin: 10px 0;
-		width: 25%;
-	}
 }


### PR DESCRIPTION
This fixes some IE bugs in #415.
- Domain input height in IE11
- `x` clear button on inputs
- Underline on confirm domain step
- Tooltip on login

| Before | After |
| --- | --- |
| ![virtualbox_ie11 - win7_05_08_2016_12_02_17](https://cloud.githubusercontent.com/assets/448298/17483228/356e0dfc-5d53-11e6-9b38-0d85a9b09d31.png) | ![input height](https://cloud.githubusercontent.com/assets/448298/17483237/404a118a-5d53-11e6-853e-5b943b9b5e03.png) |
| <img width="596" alt="clear button before" src="https://cloud.githubusercontent.com/assets/448298/17483103/bd4e396e-5d52-11e6-919f-1a1a54c9715c.png"> | ![clear button](https://cloud.githubusercontent.com/assets/448298/17483099/b8bf4334-5d52-11e6-8deb-7fc0fac04668.png) |
| <img width="471" alt="screen shot 2016-08-05 at 11 50 59" src="https://cloud.githubusercontent.com/assets/448298/17483167/fe2acbdc-5d52-11e6-8165-a6678f3f455f.png"> | ![underline](https://cloud.githubusercontent.com/assets/448298/17483179/0cec5fa0-5d53-11e6-8bf5-5a34a2c991f5.png) |
| ![virtualbox_msedge - win10_preview_05_08_2016_11_52_31](https://cloud.githubusercontent.com/assets/448298/17483189/17183b02-5d53-11e6-8fc1-3bf09f643a08.png) | ![virtualbox_ie11 - win7_08_08_2016_10_22_10](https://cloud.githubusercontent.com/assets/448298/17483212/2591f0c4-5d53-11e6-9e10-f92e027e97a6.png) |

**Review**
- [x] Product
- [ ] Code
