### PR TITLE
Copy review: missing period in domain search error

### DIFF
--- a/app/lib/domains/index.js
+++ b/app/lib/domains/index.js
@@ -108,7 +108,7 @@ export const validateDomain = query => {
 	}
 
 	if ( query.length > 63 ) {
-		return { query: i18n.translate( 'Choose a shorter domain, up to 63 characters (not including the ".blog" part)' ) };
+		return { query: i18n.translate( 'Choose a shorter domain, up to 63 characters (not including the ".blog" part).' ) };
 	}
 
 	if ( query.charAt( 0 ) === '-' ) {


### PR DESCRIPTION
Very minor fix to add a period to an error on the home page domain field.
- [ ] code
