### PR TITLE
Remove link on powered by wpcom tooltip

### DIFF
--- a/app/components/ui/connect-user/footer/index.js
+++ b/app/components/ui/connect-user/footer/index.js
@@ -11,8 +11,6 @@ const Footer = () => {
 	return (
 		<div className={ styles.footer }>
 			<Tooltip
-				href="https://wordpress.com"
-				target="_blank"
 				text={ i18n.translate( 'Your account will be linked with a new or existing account on WordPress.com.' ) }>
 				{ i18n.translate( 'Powered by WordPress.com' ) }
 			</Tooltip>


### PR DESCRIPTION
This PR fixes https://github.com/Automattic/delphin/issues/433 by removing the link to WordPress.com on the "powered by WordPress.com" tooltip. 

The interaction here is confusing on mobile, where there is no hover interaction. The user taps on the powered by text and is immediately taken to a new tab, which is very disorienting.
