### PR TITLE
Update the domain to be lowercase on `SunriseHome`

### DIFF
--- a/app/actions/domain-price.js
+++ b/app/actions/domain-price.js
@@ -8,8 +8,10 @@ import {
 } from 'reducers/action-types';
 import { withTld } from 'lib/domains';
 
+const normalizeQuery = query => query.trim().toLowerCase();
+
 export function fetchDomainPrice( domainQuery = '' ) {
-	const queryWithTld = withTld( domainQuery );
+	const queryWithTld = withTld( normalizeQuery( domainQuery ) );
 
 	return {
 		type: WPCOM_REQUEST,

--- a/app/components/ui/sunrise-home/index.js
+++ b/app/components/ui/sunrise-home/index.js
@@ -25,7 +25,7 @@ const SunriseHome = React.createClass( {
 	},
 
 	handleSubmit() {
-		const query = withTld( this.props.values.query.trim() );
+		const query = withTld( this.props.values.query );
 		this.props.fetchDomainPrice( query ).then( action => {
 			this.props.selectDomain( action.result );
 			this.props.redirectToConfirmDomain();


### PR DESCRIPTION
Fixes #429.

The API only returns lowercase domains, so the data is mismatched when the user submits an uppercase query.

**Testing**
- Visit `/`
- Enter a query with an uppercase letter (e.g. `Foobar`) and submit.
- Assert that the domain on `/confirm-domain` is lowercase and ends in `.live`.
- [x] Code
- [x] Product
