### PR TITLE
Forms: Set box-shadow on form fields to none for iOS

### DIFF
--- a/app/components/ui/form/styles.scss
+++ b/app/components/ui/form/styles.scss
@@ -67,6 +67,7 @@
 	select {
 		border: 1px solid $gray-medium;
 		border-radius: 0;
+		box-shadow: none;
 		box-sizing: border-box;
 		display: block;
 		font-size: 1.6rem;


### PR DESCRIPTION
This attempts to fix https://github.com/Automattic/delphin/issues/431, where a box-shadow is showing up on all text fields in iOS.

I need to merge and test this as it's only showing up on iOS itself and I don't have my phone set up with my sandbox.
