### PR TITLE
Forms: Really fix the box shadow on iOS

### DIFF
--- a/app/components/ui/form/styles.scss
+++ b/app/components/ui/form/styles.scss
@@ -65,6 +65,7 @@
 
 	input,
 	select {
+		appearance: none;
 		border: 1px solid $gray-medium;
 		border-radius: 0;
 		box-shadow: none;


### PR DESCRIPTION
This is a real fix for https://github.com/Automattic/delphin/issues/431, which I previously tried to fix in https://github.com/Automattic/delphin/pull/442.

I've tested this one using the Safari remote debugging tool (HT @danhauk) and it really fixes the issue this time.
