### PR TITLE
Switched images from calypso to delphin's CDN

### DIFF
--- a/app/components/ui/checkout-review/index.js
+++ b/app/components/ui/checkout-review/index.js
@@ -26,13 +26,13 @@ class CheckoutReview extends React.Component {
 
 	renderPaymentReview() {
 		const ccSuffix = this.props.checkout.number.substring( this.props.checkout.number.length - 4 );
-		const ccType = card.type( this.props.checkout.number );
+		const ccType = card.type( this.props.checkout.number ).replace( / /g, '' ).toLowerCase();
 
 		return <section className={ styles.paymentReview }>
 			<h3 className={ styles.paymentTitle }>{ i18n.translate( 'Total' ) }</h3>
 			<div className={ styles.paymentLine }>
 				<div className={ styles.creditCard }>
-					<span className={ styles.cardType + ' ' + styles[ ccType.toLowerCase() ] }></span>
+					<span className={ styles.cardType + ' ' + styles[ ccType ] }></span>
 					<span className={ styles.cardNumber }>**** { ccSuffix }</span>
 				</div>
 				<div className={ styles.cost }>

--- a/app/components/ui/checkout-review/styles.scss
+++ b/app/components/ui/checkout-review/styles.scss
@@ -151,7 +151,7 @@ $card-type-width: 32px;
 	background-image: url( https://s0.wordpress.com/i/delphin/cc-visa.svg );
 }
 
-.amex {
+.americanexpress {
 	background-image: url( https://s0.wordpress.com/i/delphin/cc-amex.svg );
 }
 


### PR DESCRIPTION
This pull request changes cc images from calypso's to delphin's cdn
so it'll be visible when sandboxed.

![screen shot 2016-08-09 at 10 55 48 am](https://cloud.githubusercontent.com/assets/326402/17508917/100a3702-5e20-11e6-8584-4a6920c18328.png)

Thanks to @drewblaisdell for uploading [them](https://github.com/Automattic/delphin/issues/323#issuecomment-238382145)
#### Testing instructions
1. Run `git checkout update/confirm-checkout-cc-images` and start your server, or open a [live branch](https://delphin.live/?branch=update/confirm-checkout-cc-images)
2. Go to checkout review page after completing the flow on [Delphin](http://delphin.localhost:1337/)
3. Check that the cc image is displayed according to your cc type, you can get different types here: http://www.getcreditcardnumbers.com/
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
