### PR TITLE
Use `.blog` as default TLD

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -5,8 +5,8 @@ const NODE_ENV = process.env.NODE_ENV,
 	productionOnly = NODE_ENV === 'production';
 
 const config = {
-	available_tlds: [ 'live' ],
-	default_tld: 'live',
+	available_tlds: [ 'blog' ],
+	default_tld: 'blog',
 	default_search_sort: 'recommended',
 	env: NODE_ENV || 'development',
 	i18n_default_locale_slug: 'en',

--- a/app/lib/domains/tests/index.js
+++ b/app/lib/domains/tests/index.js
@@ -112,18 +112,18 @@ describe( 'lib/domains', () => {
 	} );
 
 	describe( 'isDomainSearch', () => {
-		it( 'should return true for valid .live domains', () => {
-			expect( isDomainSearch( 'foo.live' ) ).toBe( true );
-			expect( isDomainSearch( 'foo-bar.live' ) ).toBe( true );
-			expect( isDomainSearch( 'foo0.live' ) ).toBe( true );
+		it( 'should return true for valid .blog domains', () => {
+			expect( isDomainSearch( 'foo.blog' ) ).toBe( true );
+			expect( isDomainSearch( 'foo-bar.blog' ) ).toBe( true );
+			expect( isDomainSearch( 'foo0.blog' ) ).toBe( true );
 		} );
 
-		it( 'should return false for invalid .live domains', () => {
-			expect( isDomainSearch( 'foo-.live' ) ).toBe( false );
-			expect( isDomainSearch( 'foo bar.live' ) ).toBe( false );
+		it( 'should return false for invalid .blog domains', () => {
+			expect( isDomainSearch( 'foo-.blog' ) ).toBe( false );
+			expect( isDomainSearch( 'foo bar.blog' ) ).toBe( false );
 		} );
 
-		it( 'should return false for non-.live domains', () => {
+		it( 'should return false for non-.blog domains', () => {
 			expect( isDomainSearch( 'foo.com' ) ).toBe( false );
 		} );
 


### PR DESCRIPTION
We have been using `.live` for testing, but need to make this update now that we have actual premium domains with D2473-code.

**Testing**
- Apply D2473-code.
- Visit `/`.
- Search for a normal domain (e.g. `foobar.blog`).
- Assert that the premium flag is not displayed and that the total cost is $250.
- Search for a normal domain (e.g. `incredible.blog`).
- Assert that the premium flag is displayed and that the domain costs >$250.

**Note:** The API doesn't add commas to large prices. I added an issue for changing this here: https://github.com/Automattic/delphin/issues/459
- [x] Code
- [x] Product
