### PR TITLE
Use `pathname` from `window.location` instead of `location` prop

### DIFF
--- a/app/lib/analytics/with-page-view.js
+++ b/app/lib/analytics/with-page-view.js
@@ -10,7 +10,9 @@ import { recordPageView } from 'actions/analytics';
 export default ( WrappedComponent, title ) => {
 	class WithPageView extends React.Component {
 		componentDidMount() {
-			this.props.recordPageView( this.props.location.pathname, title );
+			if ( process.env.BROWSER ) {
+				this.props.recordPageView( window.location.pathname, title );
+			}
 		}
 
 		render() {
@@ -23,7 +25,6 @@ export default ( WrappedComponent, title ) => {
 	}
 
 	WithPageView.propTypes = {
-		location: PropTypes.object.isRequired,
 		recordPageView: PropTypes.func.isRequired
 	};
 


### PR DESCRIPTION
Fixes #452.

`ContactInformation` was not properly logging its path when mounted because the `location` prop used in `withPageView` was being overwritten by the `location` prop `ContactInformation` uses to autoselect the user's current country.

This PR fixes this by using the pathname from `window.location` if we're in the browser environment, so that we don't need to disallow using a custom `location` prop for every top-level component. I don't think we shouldn't need to worry about calling the endpoint for page views on the server right now, so using `window` seems reasonable here -- I'm interested to hear what @yurynix thinks about that though. :)

**Testing**
- Enable tracks logging by updating line 18 of `app/config/index.js` to read `tracks_enabled: true`
- Start the server.
- Visit `/` and execute `localStorage.setItem( 'debug', 'delphin:analytics' );` in the console.
- Refresh the page.
- Assert that the `delphin_page_view` events now logged in the console have a `path` prop.
- Proceed until `/contact-information`.
- Assert that the `delphin_page_view` event on `ContactInformation` [has the correct `path` prop](https://cloudup.com/cT7dnl1tMJ5).
- [x] Code
- [x] Product
