### PR TITLE
Fix signing in with a link for accounts with 2FA enabled

### DIFF
--- a/app/components/ui/connect-user/verify-user/index.js
+++ b/app/components/ui/connect-user/verify-user/index.js
@@ -38,16 +38,6 @@ const VerifyUser = React.createClass( {
 	componentDidMount() {
 		const { query } = this.props;
 
-		if ( this.props.isLoggedIn || ! this.props.hasSelectedDomain ) {
-			this.props.redirect( 'home' );
-
-			return;
-		} else if ( ! this.props.user.wasCreated ) {
-			this.props.redirect( 'signupUser' );
-
-			return;
-		}
-
 		if ( this.isUsingCodeFromQuery() ) {
 			if ( query.domain ) {
 				this.props.selectDomain( { domain_name: query.domain } );
@@ -55,6 +45,14 @@ const VerifyUser = React.createClass( {
 
 			this.props.connectUserComplete( Object.assign( {}, query, { twoFactorAuthenticationEnabled: true } ) );
 			this.props.updateCode( query.code );
+		} else if ( this.props.isLoggedIn || ! this.props.hasSelectedDomain ) {
+			this.props.redirect( 'home' );
+
+			return;
+		} else if ( ! this.props.user.wasCreated ) {
+			this.props.redirect( 'signupUser' );
+
+			return;
 		}
 
 		this.props.recordPageView();


### PR DESCRIPTION
Previously, the sign-in link took users with 2FA enabled to the home page. Now, the users are taken to the verify step with the code filled in.

**Testing**
- Visit `/` and proceed until you log in as a user with 2fa enabled.
- Click the sign in link in the email you are sent.
- Assert that you are taken to the verify step with the code filled in, and that you can enter your 2FA code and log in.
- [x] Code
- [x] Product
