### PR TITLE
Responsive: Change containers to full-bleed on small screens

### DIFF
--- a/app/components/ui/checkout-review/styles.scss
+++ b/app/components/ui/checkout-review/styles.scss
@@ -35,6 +35,7 @@
 		}
 
 		@include breakpoint( '<480px' ) {
+			bottom: -1rem;
 			margin-left: -15px;
 		}
 	}
@@ -78,6 +79,10 @@
 .contact-review {
 	line-height: 1.5;
 	padding: 30px 0;
+
+	@include breakpoint( '<480px' ) {
+		padding-top: 0;
+	}
 }
 
 .payment-review {
@@ -94,9 +99,13 @@
 	}
 
 	@include breakpoint( '<480px' ) {
+		background: transparent;
+		border-bottom: 1px solid $gray-medium;
+		border-color: $gray-medium;
+		margin-bottom: 30px;
 		margin-left: -15px;
 		margin-right: -15px;
-		padding: 15px;
+		padding: 15px 15px 20px;
 	}
 }
 

--- a/app/components/ui/checkout/styles.scss
+++ b/app/components/ui/checkout/styles.scss
@@ -42,9 +42,10 @@
 	}
 
 	@include breakpoint( '<480px' ) {
-		margin-bottom: 15px;
-		margin-top: 15px;
-		padding: 15px;
+		background-color: transparent;
+		border-color: $gray-medium;
+		margin: 15px -20px 0;
+		padding: 15px 20px;
 	}
 }
 

--- a/app/components/ui/form/styles.scss
+++ b/app/components/ui/form/styles.scss
@@ -15,8 +15,8 @@
 		border: 0;
 		border-radius: 0;
 		margin-bottom: 0;
-		margin-left: 0px;
-		margin-right: 0px;
+		margin-left: 0;
+		margin-right: 0;
 		max-width: 100%;
 		padding: 30px 20px 0;
 	}
@@ -46,8 +46,11 @@ input::-ms-reveal {
 	word-wrap: break-word;
 
 	@include breakpoint( '<480px' ) {
+		background: transparent;
+		border-bottom: 1px solid $gray-medium;
 		font-size: 1.4rem;
-		padding: 15px;
+		margin: -30px -20px 25px;
+		padding: 20px;
 	}
 }
 

--- a/app/components/ui/sunrise-step/form/styles.scss
+++ b/app/components/ui/sunrise-step/form/styles.scss
@@ -13,8 +13,8 @@
 	@include breakpoint( '<480px' ) {
 		border: 0;
 		border-radius: 0;
-		margin-left: 0px;
-		margin-right: 0px;
+		margin-left: 0;
+		margin-right: 0;
 		max-width: 100%;
 		padding: 30px 20px;
 	}


### PR DESCRIPTION
Fixes part of #443.

Before:

![image](https://cloud.githubusercontent.com/assets/12596797/17599353/aa6c276c-5fcc-11e6-9b69-d18197193eb1.png)

After:

| ![image](https://cloud.githubusercontent.com/assets/12596797/17599676/39b15702-5fce-11e6-8ea6-c68483f7d633.png) | ![image](https://cloud.githubusercontent.com/assets/12596797/17599729/71fb09f0-5fce-11e6-9e21-9d871e11b893.png) | ![image](https://cloud.githubusercontent.com/assets/12596797/17599737/84cd4d04-5fce-11e6-8191-220b7291bba4.png) |
| --- | --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/12596797/17599776/b2502198-5fce-11e6-939b-cbfc45d73372.png) | ![image](https://cloud.githubusercontent.com/assets/12596797/17599859/138c2060-5fcf-11e6-882c-ad5f0cafa953.png) |  |
- [x] Design
- [x] Code
