### PR TITLE
Fix invisible text in IE11 in `Select`

### DIFF
--- a/app/components/ui/form/select/styles.scss
+++ b/app/components/ui/form/select/styles.scss
@@ -48,6 +48,7 @@
 	// IE: Remove default background and color styles on focus
 	&::-ms-value {
 		background: none;
+		color: $black;
 	}
 
 	// Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002


### PR DESCRIPTION
Fixes #457.

<img width="1280" alt="screen shot 2016-08-11 at 4 06 06 pm" src="https://cloud.githubusercontent.com/assets/1130674/17603154/e59dab88-5fdd-11e6-884e-652f7b06c77f.png">

Apparently IE defaults the text color to white on a focused select element if you set a rule for `-ms-value`. This PR updates the CSS to update the color to black so that the text on focused `<Select />` inputs is no longer invisible.

**Testing**
- Visit `ContactInformation` in IE11.
- Click on the country select box.
- Select a different country. The box will collapse but the select will still be focused.
- Assert that the text is visible like in the screenshot above.
- [x] Code
- [x] Product
