### PR TITLE
Set `process.env` properties on the server

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -3,7 +3,8 @@ var baseConfig = require( './webpack.base.config' ),
 	fs = require( 'fs' ),
 	merge = require( 'webpack-merge' ),
 	path = require( 'path' ),
-	webpack = require( 'webpack' );
+	webpack = require( 'webpack' ),
+	NODE_ENV = process.env.NODE_ENV || 'development';
 
 function getExternals() {
 	var externals = {};
@@ -41,7 +42,13 @@ var config = merge.smart( baseConfig, {
 
 	plugins: [
 		// inject source map support on top of the build file
-		new webpack.BannerPlugin( 'require("source-map-support").install();', { raw: true, entryOnly: false } )
+		new webpack.BannerPlugin( 'require("source-map-support").install();', { raw: true, entryOnly: false } ),
+		new webpack.DefinePlugin( {
+			'process.env': {
+				NODE_ENV: JSON.stringify( NODE_ENV ),
+				BROWSER: JSON.stringify( false )
+			}
+		} )
 	]
 } );
 


### PR DESCRIPTION
`process.env.BROWSER` is, for some unknown reason, set to a string on @danhauk's machine. Setting this property explicitly in the server's webpack config fixes it, and improves this flag as it is now `false` as opposed to `undefined` on the server.
