### PR TITLE
Use the correct `product_slug` in the application cost selector

### DIFF
--- a/app/reducers/checkout/selectors.js
+++ b/app/reducers/checkout/selectors.js
@@ -20,7 +20,7 @@ export const getSelectedDomainCost = state => {
 };
 
 export const getSelectedDomainApplicationCost = state => {
-	const applicationCostDetail = getSelectedDomainPriceDetails( state ).find( detail => detail.productSlug === 'delphin-domain-application-fee' );
+	const applicationCostDetail = getSelectedDomainPriceDetails( state ).find( detail => detail.productSlug === 'delphin-domain-app' );
 
 	return applicationCostDetail ? applicationCostDetail.cost : null;
 };


### PR DESCRIPTION
Fixes #476.

We shortened the product slug of the application product but did not update Delphin to handle the new value. This PR updates the application cost selector to use the new product slug.

**Testing**
- Visit `/`.
- Enter a domain name and submit.
- Assert that you see `+ $220 APPLICATION FEE` instead of `+ APPLICATION FEE` in the content of the page.
- [x] Code
- [x] Product
