### PR TITLE
Only clear `state` field if switching from one country to another

### DIFF
--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -69,8 +69,12 @@ class ContactInformation extends React.Component {
 		if ( this.props.fields.countryCode.value !== nextProps.fields.countryCode.value ) {
 			this.props.fetchStates( nextProps.fields.countryCode.value );
 
-			// Resets the state field every time the user selects a different country
-			this.props.fields.state.onChange( '' );
+			if ( this.props.fields.countryCode.value ) {
+				// Reset the state field every time the user selects a
+				// different country, but only if a country was previously
+				// selected
+				this.props.fields.state.onChange( '' );
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses part of #418.

Currently, `state` is not autofilled even if your user has saved contact information with a `state` property. This is because we clear the state when the country code changes, so when the country code changes from an empty string to an actual country code (i.e. when the user's location loads), we are clearing the state.

This PR updates `ContactInformation` to only clear the state if switching from one country to another.

**Testing**
Make sure you're testing with an account with a `state` property in its contact information. There used to be a bug where we were not saving this information because the name was mismatched. You can tell if your account has this information in the API by seeing if the state field is prefilled in the contact information part of checkout in Calypso.
- Sign in with this account.
- Visit `ContactInformation` and assert that the state field is populated with your saved information.
- [x] Code
- [x] Product
