### PR TITLE
Checkout: Fix localization of the progress bar

### DIFF
--- a/app/components/ui/checkout-progressbar/index.js
+++ b/app/components/ui/checkout-progressbar/index.js
@@ -24,15 +24,15 @@ function getStepClassName( currentStepIndex, stepIndex ) {
 	return classes.join( ' ' );
 }
 
-const steps = [
-	i18n.translate( 'search' ),
-	i18n.translate( 'sign in' ),
-	i18n.translate( 'profile' ),
-	i18n.translate( 'checkout' )
-];
-
 function Progressbar( props ) {
 	const currentStepIndex = props.currentStep;
+
+	const steps = [
+		i18n.translate( 'search' ),
+		i18n.translate( 'sign in' ),
+		i18n.translate( 'profile' ),
+		i18n.translate( 'checkout' )
+	];
 
 	return <ol className={ props.className + ' ' + styles.progressbar }>
 		{


### PR DESCRIPTION
This pull request fixes labels in the progress bar so they are displayed in the language selected by the user. Previously only the language selected during bootstrapping would be displayed:

![screenshot](https://cloud.githubusercontent.com/assets/594356/17699866/84fd253a-63c3-11e6-940a-7ff6464e6e98.png)
#### Testing instructions
1. Run `git checkout fix/translations` and start your server, or open a [live branch](https://delphin.live/?branch=fix/translations)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Proceed to the `Contact Information` page
4. Check that the progress bar is displayed in English
5. Select a different language using the language picker at the bottom of the page
6. Check that the progress bar is now displayed in the selected language
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
