### PR TITLE
Success: update name and URL for domain auction provider

### DIFF
--- a/app/components/ui/success/index.js
+++ b/app/components/ui/success/index.js
@@ -76,7 +76,7 @@ class Success extends React.Component {
 
 						<TrackingLink
 							className={ styles.button }
-							to="https://sedo.com/"
+							to="https://sedo.com/member/register.php#1"
 							eventName="delphin_thank_you_click"
 							target="_blank">
 							{ i18n.translate( 'Sign up at %(auctionPartnerName)s', {


### PR DESCRIPTION
This PR updates the name and URL for our domain auction provider from NameJet to Sedo.
#### Testing instructions
1. Run `git checkout update/auction-provider` and start your server
2. Open the [`Home` page](http://delphin.localhost:1337/) and go through the application flow
3. When you git `/success` make sure there are no mentions to NameJet, and that the button points to Sedo's page.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
