### PR TITLE
i18n: add French as an option in the language picker

### DIFF
--- a/app/components/ui/language-picker/languages.js
+++ b/app/components/ui/language-picker/languages.js
@@ -4,6 +4,10 @@ export default [
 		name: 'English'
 	},
 	{
+		locale: 'fr',
+		name: 'Français'
+	},
+	{
 		locale: 'es',
 		name: 'Español'
 	},


### PR DESCRIPTION
Fixes #492. French was missing in the options in the Language Picker. This PR fixes it by adding it back in the language definitions file.
#### Testing instructions
1. Run `git checkout update/language-options` and start your server.
2. Open the [`Home` page](http://delphin.localhost:1337/) and click the language picker in the bottom right corner of the page.
3. Check that "Français" is listed in the options, and that the site switches to French when that is selected.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
