### PR TITLE
Analytics: Enable Google Analytics

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -26,6 +26,7 @@ const config = {
 		rest_api_oauth_client_secret: '7FVcj4q9nDvX3ic812oAGDR2oZFjSk0woryR0rRmNIO5Gn7k6HibTIlhvC7Wmof9'
 	},
 	wordnik_api_key: '0a2ae295fc390957bd00807a19d093fb5c8ea6aaa2f1d55a0',
+	google_analytics_key: 'UA-10673494-28',
 	google_translate_api_key: 'AIzaSyBgMoRbT8VSbHD4G9Exdog3g7cFE4TXuPU'
 };
 


### PR DESCRIPTION
This pull request enables Google Analytics in production with the right property identifier. Note right now we only track page views with this tracking tool, not events.

![screenshot](https://cloud.githubusercontent.com/assets/594356/17705681/80fa41e6-63d9-11e6-9dbd-ba1415f10448.png)
#### Testing instructions
1. Run `git checkout add/google-analytics` and start your server, or open a [live branch](https://delphin.live/?branch=add/google-analytics)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Open the network tab in your browser developer tools
4. Check that a request to http://www.google-analytics.com/analytics.js is sent
5. Check that a request to http://www.google-analytics.com/r/collect is sent
6. Enter a domain name and click the `Get started` button
7. Check that a request to http://www.google-analytics.com/r/collect is sent again
#### Additional notes

I added an additional commit to ease testing that enables Google Analytics in development. This commit **must be removed** before merging this pull request. To make sure we don't forget about it, this commit also makes the tests fail.
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
