### PR TITLE
Update styling for global notices

### DIFF
--- a/app/components/ui/notices/notice.js
+++ b/app/components/ui/notices/notice.js
@@ -10,7 +10,13 @@ import styles from './styles.scss';
 const Notice = function( { notice, removeNotice } ) {
 	return (
 		<div className={ classNames( styles.notice, notice.status ) }>
-			<p>{ notice.message }</p>
+			<Gridicon
+				className={ styles.noticeIcon }
+				icon="notice-outline"
+				size="32"
+			/>
+
+			{ notice.message }
 
 			<span className={ styles.remove } onClick={ removeNotice }>
 				<Gridicon

--- a/app/components/ui/notices/styles.scss
+++ b/app/components/ui/notices/styles.scss
@@ -1,13 +1,17 @@
 @import 'app/styles/colors';
+@import 'app/styles/breakpoints';
 
 .notice {
 	animation-duration: 0.3s;
 	animation-name: animSlideTop;
 	animation-timing-function: cubic-bezier( 0.7, 0, 0.3, 1.2 );
-	background: rgba( $alert-blue, 0.9 );
+	background: rgba( $alert-red, 0.9 );
+	box-shadow: inset 52px 0 rgba( $black, 0.2 );
+	box-sizing: border-box;
 	color: $white;
 	font-size: 1.6rem;
 	left: 0;
+	padding: 20px 40px 20px 62px;
 	position: fixed;
 	top: 0;
 	width: 100%;
@@ -21,14 +25,20 @@
 		background: rgba( $alert-green, 0.9 );
 	}
 
-	p {
+	.notice-icon {
 		animation-delay: 0.2s;
 		animation-duration: 0.2s;
 		animation-fill-mode: both;
 		animation-name: animScaleUp;
-		display: inline-block;
-		margin: 0;
-		padding: 20px;
+		display: block;
+		fill: $white;
+		left: 10px;
+		position: absolute;
+		top: calc( 50% - 16px );
+	}
+
+	@include breakpoint( '<480px' ) {
+		font-size: 1.4rem;
 	}
 }
 
@@ -36,7 +46,7 @@
 	cursor: pointer;
 	position: absolute;
 	right: 20px;
-	top: 20px;
+	top: calc( 50% - 12px );
 	transition: background 0.3s;
 
 	.gridicon {
@@ -47,6 +57,10 @@
 	&:focus {
 		background: rgba( $white, 0.2 );
 		outline: none;
+	}
+
+	@include breakpoint( '<480px' ) {
+		right: 10px;
 	}
 }
 


### PR DESCRIPTION
Fixes #498. Making global notices look better.

Before:
<img width="744" alt="screen shot 2016-08-16 at 11 53 44" src="https://cloud.githubusercontent.com/assets/448298/17705967/3dda175a-63a8-11e6-8b99-89ee2b3aa86d.png">

After:
<img width="745" alt="screen shot 2016-08-16 at 12 15 53" src="https://cloud.githubusercontent.com/assets/448298/17706892/dc9e978c-63ab-11e6-9464-4fd4409445a9.png">

**To test**
I'm sure there's a better way, but the way I've been testing is:
1. Start at homepage and go through steps until the magic link email is sent
2. Copy the link in the magic link email (don't click)
3. Paste the URL in a new tab and change the `code=` query string to make the code invalid
4. Confirm that the error notice appears like the above
- [x] Code
- [x] Design
