### PR TITLE
Analytics: add tracking to locale switching

### DIFF
--- a/app/components/containers/language-picker.js
+++ b/app/components/containers/language-picker.js
@@ -7,12 +7,16 @@ import { hideSelect, showSelect } from 'actions/language-picker';
 import LanguagePicker from 'components/ui/language-picker';
 import { isSelectVisible } from 'reducers/ui/language-picker/selectors';
 import { switchLocale } from 'actions/i18n';
+import { withAnalytics, recordTracksEvent } from 'actions/analytics';
 
 export default connect(
 	state => ( { isSelectVisible: isSelectVisible( state ) } ),
 	dispatch => bindActionCreators( {
 		hideSelect,
 		showSelect,
-		switchLocale,
+		switchLocale: withAnalytics(
+			locale => recordTracksEvent( 'delphin_locale_switch', { locale: locale } ),
+			switchLocale
+		),
 	}, dispatch )
 )( LanguagePicker );


### PR DESCRIPTION
This pull request fixes #451 by recording an event when a user switches languages using the language picker.
#### Testing instructions
1. Run `git checkout add/language-switching-tracking`
2. Enable tracking by setting `tracks_enabled: true` in `/app/config/index.js`
3. Run `localStorage.setItem('debug', 'delphin:analytics');` in your browser's console. 
4. Open the [`Home` page](http://delphin.localhost:1337/) and use the language picker in the bottom right corner to switch languages.
5. Check that an `delphin_locale_switch` event is displayed in your console, and that the `locale` property is set to the language you selected.
#### Reviews
- [x] Code
- [ ] Product

@Automattic/sdev-feed
