### PR TITLE
Language Picker: add missing languages (Russian and Chinese - Taiwan

### DIFF
--- a/app/components/ui/language-picker/languages.js
+++ b/app/components/ui/language-picker/languages.js
@@ -24,6 +24,10 @@ export default [
 		name: 'עברית'
 	},
 	{
+		locale: 'ru',
+		name: 'Русский'
+	},
+	{
 		locale: 'ja',
 		name: '日本語'
 	},
@@ -50,6 +54,10 @@ export default [
 	{
 		locale: 'zh-cn',
 		name: '中文(简体)'
+	},
+	{
+		locale: 'zh-tw',
+		name: '中文(繁體)'
 	},
 	{
 		locale: 'ar',


### PR DESCRIPTION
Fixes #492 -- follow-up to #499. Russian and Chinese (Taiwan) were missing in the options in the Language Picker. This PR fixes it by adding these languages to the language definitions file.
#### Testing instructions
1. Run `git checkout update/language-options` and start your server.
2. Open the [`Home` page](http://delphin.localhost:1337/) and click the language picker in the bottom right corner of the page.
3. Check that "Русский" (Russian) and "中文(繁體)" (Chinese - Taiwan) are listed in the options, and that the site switches to these languages when they're selected.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
