### PR TITLE
Add `canonical_path` prop to the `recordPageView` event

### DIFF
--- a/app/lib/analytics/index.js
+++ b/app/lib/analytics/index.js
@@ -13,6 +13,7 @@ const debug = debugFactory( 'delphin:analytics' );
  */
 import config, { isEnabled } from 'config';
 import { loadScript } from 'lib/load-script';
+import { stripLocaleSlug } from 'lib/routes';
 
 // Load tracking scripts
 if ( process.env.BROWSER ) {
@@ -149,7 +150,8 @@ const analytics = {
 			}
 
 			analytics.tracks.recordEvent( `${ config( 'tracks_event_prefix' ) }page_view`, {
-				path: urlPath
+				path: urlPath,
+				canonical_path: stripLocaleSlug( urlPath ),
 			} );
 		}
 	},


### PR DESCRIPTION
Fixes #496.

This PR adds a `canonical_path` prop to the `recordPageView` event, which is the current page path without the locale slug.

**Testing**
- Execute `localStorage.setItem( 'debug', 'delphin:analytics' );` in your console.
- Visit `/` and assert that the `delphin_page_view` event has a `canonical_path` property set to `/`.
- Change the language to a non-en language and submit the form on the main page.
- Assert that `canonical_path` on the next page view is `/confirm-domain` while the path is `/[locale slug]/confirm-domain`.
- [x] Code
- [x] Product
