### PR TITLE
Try to log validation errors

### DIFF
--- a/app/components/containers/validation-error.js
+++ b/app/components/containers/validation-error.js
@@ -1,0 +1,95 @@
+// External dependencies
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import i18n from 'i18n-calypso';
+
+// Internal dependencies
+import { recordTracksEvent } from 'actions/analytics';
+import ValidationError from 'components/ui/form/validation-error';
+
+// eslint-disable-line camelcase
+//  discuss at: http://locutus.io/php/similar_text/
+// original by: Rafał Kukawski (http://blog.kukawski.pl)
+// bugfixed by: Chris McMacken
+// bugfixed by: Jarkko Rantavuori original by findings in stackoverflow (http://stackoverflow.com/questions/14136349/how-does-similar-text-work)
+// improved by: Markus Padourek (taken from http://www.kevinhq.com/2012/06/php-similartext-function-in-javascript_16.html)
+//   example 1: similar_text('Hello World!', 'Hello locutus!')
+//   returns 1: 8
+//   example 2: similar_text('Hello World!', null)
+//   returns 2: 0
+function similar_text( first, second, percent ) {
+	if ( first === null ||
+		second === null ||
+		typeof first === 'undefined' ||
+		typeof second === 'undefined' ) {
+		return 0;
+	}
+
+	first += '';
+	second += '';
+
+	let pos1 = 0;
+	let pos2 = 0;
+	let max = 0;
+	let firstLength = first.length;
+	let secondLength = second.length;
+	let p;
+	let q;
+	let l;
+	let sum;
+
+	for ( p = 0; p < firstLength; p++ ) {
+		for ( q = 0; q < secondLength; q++ ) {
+			for ( l = 0; ( p + l < firstLength ) && ( q + l < secondLength ) && ( first.charAt( p + l ) === second.charAt( q + l ) ); l++ ) { // eslint-disable-line max-len
+				// @todo: ^-- break up this crazy for loop and put the logic in its body
+			}
+			if ( l > max ) {
+				max = l;
+				pos1 = p;
+				pos2 = q;
+			}
+		}
+	}
+
+	sum = max;
+
+	if ( sum ) {
+		if ( pos1 && pos2 ) {
+			sum += similar_text( first.substr( 0, pos1 ), second.substr( 0, pos2 ) );
+		}
+
+		if ( ( pos1 + max < firstLength ) && ( pos2 + max < secondLength ) ) {
+			sum += similar_text(
+				first.substr( pos1 + max, firstLength - pos1 - max ),
+				second.substr( pos2 + max,
+					secondLength - pos2 - max ) );
+		}
+	}
+
+	if ( ! percent ) {
+		return sum;
+	}
+
+	return ( sum * 200 ) / ( firstLength + secondLength );
+}
+
+function tryGetTranslationKeyFromLocalized( localized ) {
+	const locale = i18n.getLocale();
+	let translationKeys = Object.keys( locale );
+
+	translationKeys = translationKeys.map( key => ( { key, score: similar_text( localized, locale[ key ] ) } ) );
+	translationKeys.sort( ( a, b ) => b.score - a.score );
+
+	return translationKeys[ 0 ].key;
+}
+
+export default connect(
+	() => ( { } ),
+	dispatch => bindActionCreators( {
+		trackFieldError: ( fieldName, fieldError ) => {
+			const translationKeyForError = i18n.getLocaleSlug() === 'en' ? null : tryGetTranslationKeyFromLocalized( fieldError );
+
+			return recordTracksEvent( 'delphin_field_validation_error', { fieldName, fieldError: translationKeyForError || fieldError } );
+		}
+	}, dispatch )
+)( ValidationError );

--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -15,7 +15,7 @@ import DocumentTitle from 'components/ui/document-title';
 import styles from './styles.scss';
 import capitalize from 'lodash/capitalize';
 import FormToggle from 'components/ui/form/form-toggle';
-import ValidationError from 'components/ui/form/validation-error';
+import ValidationError from 'components/containers/validation-error';
 import Input from 'components/ui/form/input';
 import { removeInvalidInputProps } from 'lib/form';
 import SiftScience from 'lib/sift-science';

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -11,7 +11,7 @@ import Footer from 'components/ui/connect-user/footer';
 import Form from 'components/ui/form';
 import Header from 'components/ui/connect-user/header';
 import Input from 'components/ui/form/input';
-import ValidationError from 'components/ui/form/validation-error';
+import ValidationError from 'components/containers/validation-error';
 
 const ConnectUser = React.createClass( {
 	propTypes: {

--- a/app/components/ui/connect-user/verify-user/index.js
+++ b/app/components/ui/connect-user/verify-user/index.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 import Input from 'components/ui/form/input';
 import ResendSignupEmail from './resend-signup-email';
 import styles from './styles.scss';
-import ValidationError from 'components/ui/form/validation-error';
+import ValidationError from 'components/containers/validation-error';
 
 const VerifyUser = React.createClass( {
 	propTypes: {

--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -18,7 +18,7 @@ import State from 'components/ui/form/state';
 import Input from 'components/ui/form/input';
 import styles from './styles.scss';
 import CheckoutProgressbar from 'components/ui/checkout-progressbar';
-import ValidationError from 'components/ui/form/validation-error';
+import ValidationError from 'components/containers/validation-error';
 import withPageView from 'lib/analytics/with-page-view';
 
 class ContactInformation extends React.Component {

--- a/app/components/ui/form/validation-error.js
+++ b/app/components/ui/form/validation-error.js
@@ -35,7 +35,7 @@ const isVisible = ( fields, errors, submitFailed ) => {
 	return true;
 };
 
-const ValidationError = ( { field, fields, submitFailed } ) => {
+const ValidationError = ( { field, fields, submitFailed, trackFieldError } ) => {
 	let allFields;
 
 	if ( Array.isArray( fields ) ) {
@@ -51,12 +51,19 @@ const ValidationError = ( { field, fields, submitFailed } ) => {
 			return result;
 		}
 
+		let errorMessage = null;
+
 		if ( typeof currentField.error === 'string' ) {
-			return result.concat( currentField.error );
+			errorMessage = currentField.error;
 		}
 
 		if ( typeof currentField.error === 'object' ) {
-			return result.concat( currentField.error.data );
+			errorMessage = currentField.error.data;
+		}
+
+		if ( errorMessage && typeof trackFieldError === 'function' ) {
+			trackFieldError( currentField.name, errorMessage );
+			return result.concat( errorMessage );
 		}
 
 		return result;
@@ -91,7 +98,8 @@ const ValidationError = ( { field, fields, submitFailed } ) => {
 ValidationError.propTypes = {
 	field: PropTypes.object,
 	fields: PropTypes.array,
-	submitFailed: PropTypes.bool
+	submitFailed: PropTypes.bool,
+	trackFieldError: PropTypes.func
 };
 
 export default withStyles( formStyles )( ValidationError );

--- a/app/components/ui/sunrise-home/index.js
+++ b/app/components/ui/sunrise-home/index.js
@@ -8,7 +8,7 @@ import Button from 'components/ui/button';
 import DocumentTitle from 'components/ui/document-title';
 import DomainInput from 'components/ui/domain-input';
 import styles from './styles.scss';
-import ValidationError from 'components/ui/form/validation-error';
+import ValidationError from 'components/containers/validation-error';
 import withPageView from 'lib/analytics/with-page-view';
 
 const SunriseHome = React.createClass( {


### PR DESCRIPTION
This pull request attempts to address #450 by logging errors from `ValidationError`
component and convert localized errors to translation keys in a somewhat hacky way.
#### Testing instructions
1. Run `git checkout try/track-validation-errors` and start your server, or open a [live branch](https://delphin.live/?branch=try/track-validation-errors)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that we indeed send tracking info for validation errors
#### Additional notes

Before testing you should enable in config/index.js line 18,
`features.tracks_enabled` should be `true`
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
