### PR TITLE
Revert "Set `process.env` properties on the server"

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -3,8 +3,7 @@ var baseConfig = require( './webpack.base.config' ),
 	fs = require( 'fs' ),
 	merge = require( 'webpack-merge' ),
 	path = require( 'path' ),
-	webpack = require( 'webpack' ),
-	NODE_ENV = process.env.NODE_ENV || 'development';
+	webpack = require( 'webpack' );
 
 function getExternals() {
 	var externals = {};
@@ -42,13 +41,7 @@ var config = merge.smart( baseConfig, {
 
 	plugins: [
 		// inject source map support on top of the build file
-		new webpack.BannerPlugin( 'require("source-map-support").install();', { raw: true, entryOnly: false } ),
-		new webpack.DefinePlugin( {
-			'process.env': {
-				NODE_ENV: JSON.stringify( NODE_ENV ),
-				BROWSER: JSON.stringify( false )
-			}
-		} )
+		new webpack.BannerPlugin( 'require("source-map-support").install();', { raw: true, entryOnly: false } )
 	]
 } );
 


### PR DESCRIPTION
Reverts Automattic/delphin#473

This breaks static site generation.

**Testing**
You can assert that `npm run prod:static` builds the static pages in < 10 minutes.
