### PR TITLE
Remove RTL languages from the language picker

### DIFF
--- a/app/components/ui/language-picker/languages.js
+++ b/app/components/ui/language-picker/languages.js
@@ -20,10 +20,6 @@ export default [
 		name: 'Italiano'
 	},
 	{
-		locale: 'he',
-		name: 'עברית'
-	},
-	{
 		locale: 'ru',
 		name: 'Русский'
 	},
@@ -58,10 +54,6 @@ export default [
 	{
 		locale: 'zh-tw',
 		name: '中文(繁體)'
-	},
-	{
-		locale: 'ar',
-		name: 'العربية'
 	},
 	{
 		locale: 'sv',


### PR DESCRIPTION
Fixes #530.

**Testing**
Assert that Hebrew and Arabic do not appear in the language picker.
