### PR TITLE
Success Page: Add refund copy

### DIFF
--- a/app/components/ui/success/index.js
+++ b/app/components/ui/success/index.js
@@ -64,7 +64,8 @@ class Success extends React.Component {
 						</p>
 
 						<p>
-							{ i18n.translate( 'If multiple requests are received for this domain, you will be able to bid for it in an auction, between November 14 and November 17. If your domain goes to auction and you don\'t win, your payment will be refunded.' ) }
+							{ i18n.translate( 'If multiple requests are received for this domain, you will be able to bid for it in an auction, between November 14 and November 17.' ) }&nbsp;
+							{ i18n.translate( 'Your payment will be refunded if your domain goes to auction and you don\'t win.' ) }
 						</p>
 
 						<p>


### PR DESCRIPTION
This adds copy to clarify what happens if your domains goes to auction and you don't win:

> If your domain goes to auction and you don't win, your payment will be refunded.

| Before | After |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/12596797/17797419/b4877b28-6596-11e6-8645-652f40f7a39f.png) | ![image](https://cloud.githubusercontent.com/assets/12596797/17797376/66aa6bea-6596-11e6-8345-59dc954eb2ab.png) |
