### PR TITLE
Accessibility: Remove user-scalable setting

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -4,7 +4,7 @@ html
 		if localeData
 			script(type='text/javascript')!='var localeData = ' + JSON.stringify( localeData ) + ';'
 		title=title
-		meta(name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0")
+		meta(name="viewport" content="width=device-width, initial-scale=1.0")
 		link(rel="stylesheet", href="/styles/reset.css")
 		style(type='text/css').
 			#{css}


### PR DESCRIPTION
This fixes #546 and #540 by removing the `user-scalable` setting in the viewport meta tag. Better accessibility for users who need to zoom!

There should be no visual or functional differences on desktop browsers.

**To test (on mobile):**
1. On line 196 of `server/index.js`, change `devServer.listen( port, error => {` to `devServer.listen( port, '10.0.0.91', error => {` where 10.0.0.91 is your network IP.
2. Connect your phone to the same network, and type http://10.0.0.91:1337
3. Confirm that you can scale and zoom the viewport.
- [x] Code
- [x] Product
