### PR TITLE
Update help copy when user resends the verification code

### DIFF
--- a/app/components/containers/connect-user/verify.js
+++ b/app/components/containers/connect-user/verify.js
@@ -5,7 +5,7 @@ import { change, reduxForm } from 'redux-form';
 
 // Internal dependencies
 import { addNotice } from 'actions/notices';
-import { connectUser, connectUserComplete, verifyUser } from 'actions/user';
+import { connectUser, connectUserComplete, verifyUser, clearConnectUser } from 'actions/user';
 import { getAsyncValidateFunction } from 'lib/form';
 import { getSelectedDomain, hasSelectedDomain } from 'reducers/checkout/selectors';
 import { getPath } from 'routes';
@@ -49,6 +49,10 @@ export default reduxForm(
 		addNotice,
 		connectUser,
 		connectUserComplete,
+		redirectToTryWithDifferentEmail: withAnalytics( recordTracksEvent( 'delphin_try_different_email_click' ), () => thunkDispatch => {
+			thunkDispatch( clearConnectUser() );
+			thunkDispatch( redirect( 'signupUser' ) );
+		} ),
 		recordPageView,
 		redirect,
 		selectDomain,

--- a/app/components/ui/connect-user/verify-user/index.js
+++ b/app/components/ui/connect-user/verify-user/index.js
@@ -27,6 +27,7 @@ const VerifyUser = React.createClass( {
 		query: PropTypes.object,
 		recordPageView: PropTypes.func.isRequired,
 		redirect: PropTypes.func.isRequired,
+		redirectToTryWithDifferentEmail: PropTypes.func.isRequired,
 		selectDomain: PropTypes.func.isRequired,
 		submitFailed: PropTypes.bool.isRequired,
 		submitting: PropTypes.bool.isRequired,
@@ -183,6 +184,7 @@ const VerifyUser = React.createClass( {
 
 							<ResendSignupEmail
 								connectUser={ this.props.connectUser }
+								redirectToTryWithDifferentEmail={ this.props.redirectToTryWithDifferentEmail }
 								email={ user.data.email }
 								intention={ user.intention }
 								domain={ this.props.hasSelectedDomain ? domain.domainName : null }

--- a/app/components/ui/connect-user/verify-user/resend-signup-email.js
+++ b/app/components/ui/connect-user/verify-user/resend-signup-email.js
@@ -4,17 +4,16 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
 import config from 'config';
-import { getPath } from 'routes';
 import i18n from 'i18n-calypso';
 import styles from './styles.scss';
-import TrackingLink from 'components/containers/tracking-link';
 
 const ResendSignupEmail = React.createClass( {
 	propTypes: {
 		connectUser: PropTypes.func.isRequired,
 		domain: PropTypes.string,
 		email: PropTypes.string.isRequired,
-		intention: PropTypes.string.isRequired
+		intention: PropTypes.string.isRequired,
+		redirectToTryWithDifferentEmail: PropTypes.func.isRequired,
 	},
 
 	getInitialState() {
@@ -27,6 +26,12 @@ const ResendSignupEmail = React.createClass( {
 		} );
 	},
 
+	handleTryDifferentEmailClick( event ) {
+		event.preventDefault();
+
+		this.props.redirectToTryWithDifferentEmail();
+	},
+
 	render() {
 		let text = i18n.translate(
 			"We sent the code to %(email)s. If you still can't find it, {{supportLink}}send us a message{{/supportLink}} or {{backLink}}try a different email{{/backLink}}.",
@@ -34,7 +39,7 @@ const ResendSignupEmail = React.createClass( {
 				args: { email: this.props.email },
 				components: {
 					supportLink: <a href={ config( 'support_link' ) } />,
-					backLink: <TrackingLink to={ getPath( 'signup' ) } eventName="delphin_try_different_email_click" />
+					backLink: <a href="#" onClick={ this.handleTryDifferentEmailClick } />
 				}
 			}
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/delphin/issues/400 by updating the copy when you resend the verification code to include the email address we sent to, as well as a link back to enter a different email.

| Before | After |
| --- | --- |
| <img width="476" alt="screen shot 2016-08-23 at 9 28 24 am" src="https://cloud.githubusercontent.com/assets/3011211/17893515/005d71c6-6914-11e6-8bf8-408fbd4d967e.png"> | <img width="475" alt="screen shot 2016-08-23 at 8 43 35 am" src="https://cloud.githubusercontent.com/assets/3011211/17893516/005dc824-6914-11e6-99bd-5661d81fc0f9.png"> |

Could use some dev help on the back link -- trying to use `TrackingLink` but it doesn't appear to be working.
