### PR TITLE
Use the user's selected domain name instead of `example.blog` in `SunriseConfirmDomain`

### DIFF
--- a/app/components/ui/sunrise-confirm-domain/index.js
+++ b/app/components/ui/sunrise-confirm-domain/index.js
@@ -110,7 +110,9 @@ class SunriseConfirmDomain extends React.Component {
 			<div className={ styles.feeNotice }>
 				<h3 className={ styles.headline }>{ i18n.translate( 'Get your domain, or get your money back' ) }</h3>
 				<p className={ styles.happyCircle }>
-					{ i18n.translate( 'Apply now for a chance to own the domain you want. It\'s the best way to secure example.blog before everyone else.' ) }
+					{ i18n.translate( 'Apply now for a chance to own the domain you want. It\'s the best way to secure %(domainName)s before everyone else.', {
+						args: { domainName }
+					} ) }
 				</p>
 				<p>
 					{ i18n.translate( 'It\'s also risk-free: We can\'t guarantee you\'ll get the domain, but if you don’t get it, we\'ll refund your payment in full.' ) }
@@ -155,7 +157,9 @@ class SunriseConfirmDomain extends React.Component {
 		} else if ( query ) {
 			domainName = withTld( query );
 		} else {
-			domainName = 'mydomain.blog';
+			// this is the name that is displayed before redirecting if the
+			// user accesses this page directly
+			domainName = 'example.blog';
 		}
 
 		return (


### PR DESCRIPTION
I missed an instance of `example.blog` when updating this PR: https://github.com/Automattic/delphin/pull/541/files#diff-4793735e8b93949b76a295a4655da359R92

This PR replaces `example.blog` in the copy with the user's selected domain name. It also adds a comment and changes the `mydomain.blog` placeholder to `example.blog` in the case that the user accesses this route directly with no `?query` parameter.

**Testing**
- Visit `/`
- Enter a domain name and submit.
- Assert that the domain name appears in this sentence: `Apply now for a chance to own the domain you want. It\'s the best way to secure %(domainName)s before everyone else.`
