### PR TITLE
Remove "Learn More" link

### DIFF
--- a/app/components/ui/menu/index.js
+++ b/app/components/ui/menu/index.js
@@ -11,7 +11,6 @@ import TrackingLink from 'components/containers/tracking-link';
 const Menu = () => {
 	return (
 		<menu className={ styles.menu }>
-			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to="https://dotblog.wordpress.com">{ i18n.translate( 'Learn More' ) }</TrackingLink>
 			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to={ config( 'support_link' ) }>{ i18n.translate( 'Support' ) }</TrackingLink>
 			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to="https://automattic.com/privacy/">{ i18n.translate( 'Privacy Policy' ) }</TrackingLink>
 			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to="https://wordpress.com">{ i18n.translate( 'A WordPress.com Service' ) }</TrackingLink>


### PR DESCRIPTION
We're going to redirect users from `dotblog.wordpress.com` to `get.blog` so we don't need this link right now.
