### PR TITLE
Add a new page at /learn-more

### DIFF
--- a/app/components/containers/learn-more.js
+++ b/app/components/containers/learn-more.js
@@ -1,0 +1,12 @@
+// External dependencies
+import { reduxForm } from 'redux-form';
+
+// Internal dependencies
+import LearnMore from 'components/ui/learn-more';
+
+export default reduxForm(
+	{
+		form: 'learn-more',
+		fields: [ 'domain', 'email' ],
+	}
+)( LearnMore );

--- a/app/components/ui/learn-more/index.js
+++ b/app/components/ui/learn-more/index.js
@@ -7,8 +7,10 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import DocumentTitle from 'components/ui/document-title';
 import styles from './styles.scss';
 import SunriseStep from 'components/ui/sunrise-step';
+import Button from 'components/ui/button';
+import Input from 'components/ui/form/input';
 
-const LearnMore = () => {
+const LearnMore = ( { fields } ) => {
 	return (
 		<SunriseStep>
 			<DocumentTitle title={ i18n.translate( 'Get .blog updates in your email' ) } />
@@ -18,6 +20,25 @@ const LearnMore = () => {
 					{ i18n.translate( 'Sign up to receive updates about the launch and be the first to know when you can claim your own .blog domain' ) }
 				</div>
 			</SunriseStep.Header>
+			<div className={ styles.formContainer }>
+				<form className={ styles.form }>
+					<Input
+						className={ styles.inputContainer }
+						inputClassName={ styles.input }
+						field={ fields.domain }
+						placeholder={ i18n.translate( 'What domain are you interested in?' ) }
+					/>
+
+					<Input
+						className={ styles.inputContainer }
+						inputClassName={ styles.input }
+						field={ fields.email }
+						placeholder={ i18n.translate( 'Enter your email' ) }
+					/>
+
+					<Button>{ i18n.translate( 'Get updates' ) }</Button>
+				</form>
+			</div>
 			<SunriseStep.Footer>
 				<h2>{ i18n.translate( 'How does the .blog launch work?' ) }</h2>
 				<div>
@@ -43,7 +64,8 @@ const LearnMore = () => {
 };
 
 LearnMore.propTypes = {
-	children: PropTypes.node.isRequired
+	children: PropTypes.node.isRequired,
+	fields: PropTypes.object.isRequired,
 };
 
 export default withStyles( styles )( LearnMore );

--- a/app/components/ui/learn-more/styles.scss
+++ b/app/components/ui/learn-more/styles.scss
@@ -24,3 +24,26 @@
 		font-size: 1.8rem;
 	}
 }
+
+.form-container {
+	background-color: lighten( $blue-background, 10% );
+	padding: 15px 0;
+}
+
+.form {
+	margin: 0 auto;
+	max-width: 600px;
+}
+
+.input-container {
+	display: inline-block;
+	margin-right: 15px;
+	vertical-align: bottom;
+}
+
+.input {
+	border: 0;
+	border-radius: 3px;
+	font-size: 1em;
+	padding: 20px 16px;
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -9,7 +9,7 @@ import ContactInformationContainer from 'components/containers/contact-informati
 import CheckoutReviewContainer from 'components/containers/checkout-review';
 import DefaultLayoutWithHeader from 'components/ui/layout/default-with-header';
 import Layout from 'components/ui/layout';
-import LearnMore from 'components/ui/learn-more';
+import LearnMore from 'components/containers/learn-more';
 import LoginContainer from 'components/containers/connect-user/login';
 import NoMarginLayout from 'components/ui/layout/no-margin';
 import NotFound from 'components/ui/not-found';

--- a/app/tests/routes.js
+++ b/app/tests/routes.js
@@ -7,6 +7,7 @@ jest.mock( 'components/containers/connect-user/login', () => {} );
 jest.mock( 'components/containers/connect-user/signup', () => {} );
 jest.mock( 'components/containers/connect-user/verify', () => {} );
 jest.mock( 'components/containers/contact-information', () => {} );
+jest.mock( 'components/containers/learn-more', () => {} );
 jest.mock( 'components/containers/notices', () => {} );
 jest.mock( 'components/containers/success', () => {} );
 jest.mock( 'components/containers/sunrise-confirm-domain', () => {} );
@@ -21,7 +22,6 @@ jest.mock( 'components/ui/layout/default-with-header', () => {} );
 jest.mock( 'components/ui/layout/no-margin', () => {} );
 jest.mock( 'components/ui/layout/sunrise/flow', () => {} );
 jest.mock( 'components/ui/layout/sunrise/success', () => {} );
-jest.mock( 'components/ui/learn-more', () => {} );
 jest.mock( 'components/ui/not-found', () => {} );
 
 jest.unmock( 'routes' );


### PR DESCRIPTION
This is the first part of #553. We should create the page first and commit it, before we add the styles, so that Amber can work on the mailchimp part while Cerulean add styles for the page. This will also mean that the translations can be sent in the next batch.

<img width="1436" alt="screen shot 2016-08-24 at 16 38 46" src="https://cloud.githubusercontent.com/assets/275961/17937238/449e52c8-6a19-11e6-99c9-51b18062aeb7.png">
#### Testing instructions
1. Run `git checkout add/learn-more-page` and start your server, or open a [live branch](https://delphin.live/?branch=add/learn-more-page)
2. Open the [`Learn More` page](http://delphin.localhost:1337/learn-more)
3. Check that the page looks like the screenshot above.
#### Additional notes

The styles are duplicated from the connect user component. If they aren't going to change we should import them from there.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
