### PR TITLE
Upgrade i18n-calypso so we have the correct location of the strings in the POT file

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "npm": "^3.9.6",
     "react-addons-test-utils": "^15.1.0",
     "sass-lint": "^1.8.0",
-    "serve-static": "^1.10.2",
-    "xgettext-js": "^0.3.0"
+    "serve-static": "^1.10.2"
   },
   "dependencies": {
     "@automattic/dops-components": "github:automattic/dops-components",


### PR DESCRIPTION
This PR upgrade `i18n-calypso` so we have the location of the strings in our project:

```
#: app/actions/user.js:152
msgid "You entered an invalid code. Please try again."
msgstr ""

#: app/actions/user.js:147
msgid "Enter your code just as it is in the email."
msgstr ""

#: app/components/containers/connect-user/index.js:21
msgid "Use a working email address, so you can receive our messages."
msgstr ""

...
```
### Testing instructions
- `git checkout update/i18n-calypso-3`
- `npm i`
- `npm run translate`
- Check the generated POT file at `server/build/delphin.pot`, it should contain all the strings from the js files and include one or more comments with the location of the strings in the project
### Reviews
- [x] Product
- [x] Code
