### PR TITLE
Handle API error on connect user

### DIFF
--- a/app/components/containers/connect-user/index.js
+++ b/app/components/containers/connect-user/index.js
@@ -5,6 +5,7 @@ import { reduxForm } from 'redux-form';
 import validator from 'validator';
 
 // Internal dependencies
+import { addNotice } from 'actions/notices';
 import ConnectUser from 'components/ui/connect-user';
 import { getAsyncValidateFunction } from 'lib/form';
 import { getSelectedDomain, hasSelectedDomain } from 'reducers/checkout/selectors';
@@ -39,6 +40,10 @@ export default reduxForm(
 	} ),
 	( dispatch, ownProps ) => bindActionCreators( {
 		clearConnectUser,
+		displayError: ( errorMessage ) => addNotice( {
+			message: errorMessage,
+			status: 'error'
+		} ),
 		connectUser: withAnalytics(
 			recordTracksEvent( 'delphin_signup_submit' ),
 			( fields, domain ) => connectUser( fields.email, ownProps.intention, domain )

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -18,6 +18,7 @@ const ConnectUser = React.createClass( {
 	propTypes: {
 		clearConnectUser: PropTypes.func.isRequired,
 		connectUser: PropTypes.func.isRequired,
+		displayError: PropTypes.func.isRequired,
 		domain: PropTypes.object,
 		fields: PropTypes.object.isRequired,
 		handleSubmit: PropTypes.func.isRequired,
@@ -60,7 +61,8 @@ const ConnectUser = React.createClass( {
 	},
 
 	handleSubmit() {
-		this.props.connectUser( this.props.values, this.props.domain.domainName );
+		this.props.connectUser( this.props.values, this.props.domain.domainName )
+			.catch( () => this.props.displayError( i18n.translate( 'Something went wrong. Please try again.' ) ) );
 	},
 
 	renderTermsOfService() {

--- a/app/reducers/user/connect.js
+++ b/app/reducers/user/connect.js
@@ -6,6 +6,7 @@ import {
 	CONNECT_USER,
 	CONNECT_USER_CLEAR,
 	CONNECT_USER_COMPLETE,
+	CONNECT_USER_FAIL,
 	CONNECT_USER_WARNING,
 	VERIFY_USER,
 	VERIFY_USER_COMPLETE,
@@ -54,6 +55,11 @@ export const connect = ( state = initialState, action ) => {
 				intention,
 				isRequesting: false,
 				wasCreated: true
+			} );
+
+		case CONNECT_USER_FAIL:
+			return Object.assign( {}, state, {
+				isRequesting: false
 			} );
 
 		case CONNECT_USER_WARNING:

--- a/app/reducers/user/tests/connect.js
+++ b/app/reducers/user/tests/connect.js
@@ -5,6 +5,7 @@ import {
 	CONNECT_USER,
 	CONNECT_USER_CLEAR,
 	CONNECT_USER_COMPLETE,
+	CONNECT_USER_FAIL,
 	CONNECT_USER_WARNING,
 	VERIFY_USER,
 	VERIFY_USER_COMPLETE,
@@ -159,6 +160,17 @@ describe( 'state.user.connect', () => {
 			data: null
 		}, {
 			type: VERIFY_USER_FAIL
+		} ).isRequesting ).toEqual( false );
+	} );
+
+	it( 'should update `isRequesting` if user connect fails', () => {
+		expect( connect( {
+			intention: null,
+			isRequesting: true,
+			wasCreated: false,
+			data: null
+		}, {
+			type: CONNECT_USER_FAIL
 		} ).isRequesting ).toEqual( false );
 	} );
 } );


### PR DESCRIPTION
This pull request fixes #253 by making the reducer set `isRequesting` to `false` when appropriate and the UI displaying an error notice.

![screen shot 2016-08-25 at 3 40 24 pm](https://cloud.githubusercontent.com/assets/326402/17969400/931738ae-6ada-11e6-9f24-fd53f9f2406e.png)
#### Testing instructions
1. Comment out in `ui/connect-user/index.js`:

```
        if ( this.props.isLoggedIn || ! this.props.hasSelectedDomain ) {
            this.props.redirectToHome();

            return;
        }
```
1. Run `git checkout fix/user-connect-stuck` and start your server, or open a [live branch](https://delphin.live/?branch=fix/user-connect-stuck)
2. Open the [`signup` page](http://delphin.localhost:1337/signup)
3. Kill the connection / point `public-api.wordpres.com` to a different host
4. Try login, assert that you see the error as in the screenshot
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
