### PR TITLE
Fix pages not loading in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "svg-react-loader": "^0.3.5",
     "validator": "^5.2.0",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "^1.15.1",
+    "webpack-dev-server": "1.14.1",
     "webpack-merge": "^0.12.0",
     "wpcom": "^4.9.1",
     "wpcom-proxy-request": "^2.0.0",


### PR DESCRIPTION
This pull request fixes an issue that prevents any page from loading. The content of the root directory is indeed served instead:

![screenshot](https://cloud.githubusercontent.com/assets/594356/17977293/68c55074-6af1-11e6-88d1-75fe5640aac6.png)

Loading a non-English version of a page would render the following error:

```
Cannot GET /fr
```

This issue only happens in development with the proxy used by the Webpack dev server. This is [a regression](https://github.com/webpack/webpack-dev-server/issues/566) introduced in [`webpack-dev-server`](https://www.npmjs.com/package/webpack-dev-server).
#### Testing instructions
1. Run `git checkout fix/proxy`
2. Run `npm run clean:all`, then start your server
3. Open the [`Home` page](http://delphin.localhost:1337/)
4. Check that everything works as before
5. Open the [`Home` page](http://delphin.localhost:1337/fr) in a different language
6. Check that everything works as before
#### Additional notes

While the culprit was `webpack-dev-server` this pull request also upgrades Express and Webpack to the latest available version in the process.
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
