### PR TITLE
Add `ad-tracking-middleware`

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -9,14 +9,17 @@ const config = {
 	default_tld: 'blog',
 	default_search_sort: 'recommended',
 	env: NODE_ENV || 'development',
+	google_conversion_id: 881304566,
+	google_conversion_label: 'WLR1CIHt3WkQ9seepAM',
 	hostname: 'get.blog',
 	i18n_default_locale_slug: 'en',
 	initial_number_of_search_results: 6,
 	features: {
+		ad_tracking: productionOnly,
 		boom_analytics_enabled: productionOnly,
 		google_analytics_enabled: productionOnly,
 		mc_analytics_enabled: productionOnly,
-		tracks_enabled: productionOnly
+		tracks_enabled: productionOnly,
 	},
 	languages,
 	sift_science_key: productionOnly ? 'a4f69f6759' : 'e00e878351',

--- a/client/ad-tracking-middleware/index.js
+++ b/client/ad-tracking-middleware/index.js
@@ -1,0 +1,25 @@
+// Internal dependencies
+import config, { isEnabled } from 'config';
+import { loadScript } from 'lib/load-script';
+import { TRANSACTION_CREATE_COMPLETE } from 'reducers/action-types';
+
+if ( isEnabled( 'ad_tracking' ) ) {
+	loadScript( 'https://www.googleadservices.com/pagead/conversion_async.js' );
+}
+
+export const adTrackingMiddleware = () => next => action => {
+	const { type } = action;
+
+	switch ( type ) {
+		case TRANSACTION_CREATE_COMPLETE:
+			if ( isEnabled( 'ad_tracking' ) ) {
+				window.google_trackConversion( {
+					google_conversion_id: config( 'google_conversion_id' ),
+					google_conversion_format: 3,
+					google_conversion_label: config( 'google_conversion_label' ),
+				} );
+			}
+	}
+
+	return next( action );
+};

--- a/client/index.js
+++ b/client/index.js
@@ -10,6 +10,7 @@ import { routerMiddleware, routerReducer, syncHistoryWithStore } from 'react-rou
 import thunk from 'redux-thunk';
 
 // Internal dependencies
+import { adTrackingMiddleware } from './ad-tracking-middleware';
 import { analyticsMiddleware } from './analytics-middleware';
 import config from 'config';
 import { default as wpcomMiddleware } from './wpcom-middleware';
@@ -26,6 +27,7 @@ import { switchLocaleMiddleware } from './switch-locale-middleware';
 const middlewares = [
 	routerMiddleware( browserHistory ),
 	thunk,
+	adTrackingMiddleware,
 	analyticsMiddleware,
 	logErrorNoticesMiddleware,
 	wpcomMiddleware,


### PR DESCRIPTION
Fixes #571.

This PR adds `ad-tracking-middleware`, which:
- Loads Google's `conversion_async.js` script for recording conversion. Calypso uses this as well.
- Records a conversion when the user creates transaction is created successfully.

**Testing**
- Set `ad_tracking` to `true` in `app/config/index.js` [here](https://github.com/Automattic/delphin/pull/576/files#diff-c49ff7e11c7195093020ff68ea1eccf6R18).
- Open the Network pane of the Developer Tools in Chrome.
- Open Delphin and purchase an application.
- Assert that you see a request that matches `google.com/ads` like [this](https://cloudup.com/ikQ2r3a4JMF).
- [x] Code
- [x] Product
