### PR TITLE
Update `domainKeywords` reducer to split multi-word keywords into multiple keywords when replacing

### DIFF
--- a/app/reducers/ui/domain-search/domain-keywords.js
+++ b/app/reducers/ui/domain-search/domain-keywords.js
@@ -81,7 +81,8 @@ const selectKeyword = ( state, id ) => {
 };
 
 /**
- * Returns a new state with the specified keyword updated with the given value.
+ * Returns a new state with the specified keyword replaced with one or more
+ * keywords from the given `newValue`.
  *
  * @param {object} state - current state
  * @param {object} id - id of the keyword to remove
@@ -90,16 +91,13 @@ const selectKeyword = ( state, id ) => {
  */
 const updateKeyword = ( state, id, newValue ) => {
 	return Object.assign( {}, state, {
-		keywords: state.keywords.map( ( keyword ) => {
+		keywords: state.keywords.reduce( ( keywords, keyword ) => {
 			if ( keyword.id === id ) {
-				return Object.assign( {}, keyword, {
-					value: newValue,
-					isSelected: false
-				} );
+				const newKeywords = newValue.split( ' ' ).map( createKeyword );
+				return keywords.concat( newKeywords );
 			}
-
-			return keyword;
-		} )
+			return keywords.concat( keyword );
+		}, [] )
 	} );
 };
 

--- a/app/reducers/ui/domain-search/tests/domain-keywords.js
+++ b/app/reducers/ui/domain-search/tests/domain-keywords.js
@@ -12,6 +12,7 @@ import {
 	DOMAIN_SEARCH_KEYWORD_DESELECT,
 	DOMAIN_SEARCH_LAST_KEYWORD_REMOVE,
 } from 'reducers/action-types';
+jest.unmock( 'lodash/uniqueId' );
 import domainKeywords from '../domain-keywords';
 
 jest.mock( 'routes' );
@@ -186,25 +187,26 @@ describe( 'ui.domainSearch reducer', () => {
 		} );
 	} );
 
-	it( 'should be possible to replace the selected keyword with a new value', () => {
+	it( 'should be possible to replace the selected keyword with one or more keywords', () => {
 		const initialState = {
 			inputValue: '',
 			keywords: [
-				{ value: 'foobar', id: 1, isSelected: false },
-				{ value: 'foobar', id: 2, isSelected: true },
-				{ value: 'foobar', id: 3, isSelected: false }
+				{ value: 'foobar', id: 100, isSelected: false },
+				{ value: 'foobar', id: 101, isSelected: true },
+				{ value: 'foobar', id: 102, isSelected: false }
 			]
 		};
 
 		expect( domainKeywords( initialState, {
 			type: DOMAIN_SEARCH_KEYWORD_REPLACE_SELECTED,
-			value: 'barbaz'
+			value: 'bar baz'
 		} ) ).toEqual( {
 			inputValue: '',
 			keywords: [
-				{ value: 'foobar', id: 1, isSelected: false },
-				{ value: 'barbaz', id: 2, isSelected: false },
-				{ value: 'foobar', id: 3, isSelected: false }
+				{ value: 'foobar', id: 100, isSelected: false },
+				{ value: 'bar', id: 3, isSelected: false },
+				{ value: 'baz', id: 4, isSelected: false },
+				{ value: 'foobar', id: 102, isSelected: false },
 			]
 		} );
 	} );


### PR DESCRIPTION
Fixes #147.

![vanilla](https://cloud.githubusercontent.com/assets/1130674/18105919/514a6042-6ecf-11e6-9f70-b6b65f9ea5d7.gif)

This PR updates the `domainKeywords` reducer to immediately split multi-word keyword suggestions into multiple keywords when replacing the currently selected keyword.

Note that #147 also contains an issue for hyphenated keywords wrapping which [is no longer reproducible](https://cloudup.com/cI8Cs1h7G2c).

**Testing**
- Visit `/search`
- Search for `vanilla`
- Click the `vanilla` keyword
- Click one of the multi-word suggestions below (e.g. `vanilla extract`).
- Assert that `vanilla` is replaced with `vanilla` `extract` as two separate keywords.
- [x] Code
- [x] Product
