### PR TITLE
Add the "Learn More" link back on the home page

### DIFF
--- a/app/components/ui/menu/index.js
+++ b/app/components/ui/menu/index.js
@@ -5,13 +5,14 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
 import config from 'config';
+import { getPath } from 'routes';
 import styles from './styles.scss';
 import TrackingLink from 'components/containers/tracking-link';
 
 const Menu = () => {
 	return (
 		<menu className={ styles.menu }>
-			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to="https://dotblog.wordpress.com">{ i18n.translate( 'Learn More' ) }</TrackingLink>
+			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to={ getPath( 'learnMore' ) }>{ i18n.translate( 'Learn More' ) }</TrackingLink>
 			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to={ config( 'support_link' ) }>{ i18n.translate( 'Support' ) }</TrackingLink>
 			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to="https://automattic.com/privacy/">{ i18n.translate( 'Privacy Policy' ) }</TrackingLink>
 			<TrackingLink eventName="delphin_footer_link_click" className={ styles.link } to="https://wordpress.com">{ i18n.translate( 'A WordPress.com Service' ) }</TrackingLink>


### PR DESCRIPTION
This PR adds the "Learn More" link back on the bottom left corner of the home page.

Test live: https://delphin.live/?branch=add/learn-more-link-home
