### PR TITLE
Use the new Mailchimp list set with help@get.blog

### DIFF
--- a/app/actions/learn-more.js
+++ b/app/actions/learn-more.js
@@ -7,7 +7,7 @@ export function subscribeUser( email, domainName ) {
 	return new Promise( ( resolve, reject ) => {
 		const queryParams = {
 			u: '4471f40dba4ec0e34130a91a5',
-			id: '3358410f08',
+			id: 'd1fefd318f',
 			MERGE0: email,
 			MERGE1: domainName
 		};


### PR DESCRIPTION
Try to subscribe at https://delphin.live/learn-more?branch=fix/learn-more-spam once the bug is fixed on Mailchimp's end. This is using the new list called ".blog news".
