### PR TITLE
Search: copy review

### DIFF
--- a/app/components/ui/search-input/related-words.js
+++ b/app/components/ui/search-input/related-words.js
@@ -23,7 +23,7 @@ const RelatedWords = ( { target, replace, relatedWords } ) => {
 			{ showRelatedWords && (
 				<div>
 					<h3>
-						{ i18n.translate( 'Try one of these instead of {{keyword/}}:', {
+						{ i18n.translate( 'Try one of these related terms instead of "{{keyword/}}":', {
 							components: {
 								context: 'keyword is a word a user entered to which we will display related words to follow',
 								keyword: <strong>{ target.value }</strong>

--- a/app/components/ui/search/header.js
+++ b/app/components/ui/search/header.js
@@ -16,7 +16,7 @@ const SearchHeader = ( { query, onQueryChange } ) => {
 			<SearchInputContainer
 				{ ...{ query } }
 				onQueryChange={ onQueryChange }
-				placeholder={ i18n.translate( 'Type a few keywords or an address' ) } />
+				placeholder={ i18n.translate( 'Type a few keywords or a domain' ) } />
 
 			<Link className={ styles.logo } to={ getPath( 'home' ) }>
 				<img alt="get.blog" src="https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/get-dot-blog-logo.svg" />

--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -143,7 +143,7 @@ const Search = React.createClass( {
 							} )
 						) }
 						{ ! exactMatchUnavailable && (
-							i18n.translate( 'Show me {{sortOption/}} addresses for my blog:', {
+							i18n.translate( 'Show me {{sortOption/}} domains:', {
 								components: {
 									context: 'sortOption will be one of "recommended", "unique" or "short"',
 									sortOption: this.renderSortOptions()


### PR DESCRIPTION
Fixes #588 

Small copy changes in current search flow:

To test:
- Go to /search
- Check that the search field placeholder text is: `Type a few keywords or a domain`
- Check that the description next to related words is: `Try one of these related terms instead of “example”:`
- Check that the label around the sort control is: `Show me (recommended) domains:`
- [ ] code
- [ ] product
