### PR TITLE
Sanitize profane related words

### DIFF
--- a/client/related-words-middleware/index.js
+++ b/client/related-words-middleware/index.js
@@ -1,4 +1,5 @@
 // External dependencies
+import badWords from 'badwords/object';
 import config from 'config';
 import difference from 'lodash/difference';
 import request from 'superagent';
@@ -33,6 +34,8 @@ function requestRelatedWords( word ) {
 	} );
 }
 
+const sanitizeRelatedWords = words => words.filter( word => ! badWords[ word.toLowerCase() ] );
+
 export const relatedWordsMiddleware = store => next => action => {
 	if ( action.type === DOMAIN_SUGGESTIONS_FETCH ) {
 		const state = store.getState(),
@@ -59,7 +62,7 @@ export const relatedWordsMiddleware = store => next => action => {
 					.then( ( relatedWords ) => ( { relatedWords, sourceLanguage: translation.sourceLanguage } ) )
 			)
 			.then( params => {
-				const { relatedWords } = params;
+				const relatedWords = sanitizeRelatedWords( params.relatedWords );
 
 				// We should translate the related words according to user's locale
 				if ( ! locale || locale === 'en' ) {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "babel-runtime": "^6.6.1",
+    "badwords": "^1.0.0",
     "body-parser": "^1.15.0",
     "classnames": "^2.2.5",
     "cookie-dough": "^0.0.6",


### PR DESCRIPTION
Addresses part of #586.

This PR updates `related-words-middleware` to prevent profane words from being displayed in `Search`.

Note that the new `badwords/array` import is just an array of strings.

**Testing**
- Visit `/search`
- Search for `donkey`
- Select `donkey`
- Assert that the list of related words [does not contain "ass"](https://cloudup.com/cgsrQZ82NEL).
- [x] Code
- [x] Product
