### PR TITLE
Request related words for the lowercase version of the given keyword

### DIFF
--- a/client/related-words-middleware/index.js
+++ b/client/related-words-middleware/index.js
@@ -16,6 +16,9 @@ import { isDomain } from 'lib/domains';
 import { shouldTranslateWord, translateWord } from 'lib/translate';
 
 function requestRelatedWords( word ) {
+	// Wordnik does not return related words for uppercase words
+	word = word.toLowerCase();
+
 	return new Promise( ( resolve, reject ) => {
 		request
 			.get( `https://api.wordnik.com/v4/word.json/${ encodeURIComponent( word ) }/relatedWords` +


### PR DESCRIPTION
Fixes #587.

Wordnik does not return related words for words that are capitalized. This PR updates `related-words-middleware` to only request the lowercase version of the keyword for which we are requesting related words.

**Testing**
- Visit `/search`
- Enter a proper noun that is also a word (e.g. `Ford`).
- Selecting this keyword.
- Assert that related words for `ford` [are displayed](https://cloudup.com/cSvt4fLlVxD).
- [x] Code
- [x] Product
