### PR TITLE
Bump Webpack Dev Server to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "svg-react-loader": "^0.3.5",
     "validator": "^5.2.0",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "1.14.1",
+    "webpack-dev-server": "^1.15.1",
     "webpack-merge": "^0.12.0",
     "wpcom": "^4.9.1",
     "wpcom-proxy-request": "^2.0.0",


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/delphin/pull/575 that updates the [`webpack-dev-server`](https://www.npmjs.com/package/webpack-dev-server) module to the latest available version now that the regression mentioned in https://github.com/Automattic/delphin/pull/575 [is fixed](https://github.com/webpack/webpack-dev-server/issues/562#issuecomment-244011659).
#### Testing instructions
1. Run `git checkout fix/proxy`
2. Run `npm run clean:all`, then start your server
3. Open the [`Home` page](http://delphin.localhost:1337/)
4. Check that everything works as before
5. Open the [`Home` page](http://delphin.localhost:1337/fr) in a different language
6. Check that everything works as before
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
