### PR TITLE
Display currency code by total price in `Checkout`, `CheckoutReview`, and `SunriseConfirmDomain`

### DIFF
--- a/app/components/ui/checkout-review/index.js
+++ b/app/components/ui/checkout-review/index.js
@@ -37,7 +37,7 @@ class CheckoutReview extends React.Component {
 					<span className={ styles.cardNumber }>**** { ccSuffix }</span>
 				</div>
 				<div className={ styles.cost }>
-					{ this.props.selectedDomain.totalCost }
+					{ this.props.selectedDomain.totalCost } { this.props.selectedDomain.currencyCode }
 				</div>
 			</div>
 			<TrackingLink className={ styles.editLink } to={ getPath( 'checkout' ) } eventName="delphin_edit_payment_click">{ i18n.translate( 'edit payment method' ) }</TrackingLink>

--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -273,7 +273,7 @@ const Checkout = React.createClass( {
 							</div>
 							<div className={ classnames( styles.orderItem, styles.orderTotal ) }>
 								<span>{ i18n.translate( 'Total cost' ) }</span>
-								<span>{ this.props.domain.totalCost }</span>
+								<span>{ this.props.domain.totalCost } { this.props.domain.currencyCode }</span>
 							</div>
 						</div>
 

--- a/app/components/ui/sunrise-confirm-domain/index.js
+++ b/app/components/ui/sunrise-confirm-domain/index.js
@@ -75,13 +75,13 @@ class SunriseConfirmDomain extends React.Component {
 			);
 		}
 
-		const { totalCost } = domain;
+		const { currencyCode, totalCost } = domain;
 
 		return (
 			<div>
 				<div className={ styles.priceTag }>
-					{ i18n.translate( '%(totalCost)s Early Application', {
-						args: { totalCost }
+					{ i18n.translate( '%(totalCost)s %(currencyCode)s Early Application', {
+						args: { currencyCode, totalCost }
 					} ) }
 				</div>
 				<div className={ styles.renewalInfo }>


### PR DESCRIPTION
Fixes #550. Requires D2716-code.

<img width="401" alt="screen shot 2016-09-02 at 3 26 41 pm" src="https://cloud.githubusercontent.com/assets/1130674/18215914/c86d2a0c-7121-11e6-874a-7b8ab55fc77d.png">

<img width="407" alt="screen shot 2016-09-02 at 3 20 19 pm" src="https://cloud.githubusercontent.com/assets/1130674/18215844/651dfecc-7121-11e6-958c-02fb20520bde.png">

<img width="452" alt="screen shot 2016-09-02 at 3 21 42 pm" src="https://cloud.githubusercontent.com/assets/1130674/18215842/5ddc44fc-7121-11e6-9b8f-daa67dd2f9f8.png">

This PR adds the currency code to `Checkout` and `CheckoutReview` to make it more clear to the user which currency they will be charged.

**Testing**
- Apply D2716-code.
- Point your hosts file at your sandbox IP.
- Visit `/`.
- Submit a valid domain.
- Assert that you see the currency code (`EUR`, `JPY`, `USD`, etc.) next to the total price on this page.
- Proceed to `Checkout`.
- Assert that you see the currency code (`EUR`, `JPY`, `USD`, etc.) next to the total price on this page.
- Submit valid checkout information and proceed to `CheckoutReview.
- Assert that you see the currency code (`EUR`, `JPY`, `USD`, etc.) next to the total price on this page.
- [x] Code
- [x] Design
- [x] Product
