### PR TITLE
Replace error notice with message when no domains are found for query

### DIFF
--- a/app/components/containers/search.js
+++ b/app/components/containers/search.js
@@ -14,6 +14,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		lastQuery: state.domainSearch.query,
 		results: state.domainSearch.results,
+		hasLoadedFromServer: state.domainSearch.hasLoadedFromServer,
 		isRequesting: state.domainSearch.isRequesting,
 		initialValues: { query: ownProps.location.query.q },
 		numberOfResultsToDisplay: Number( ownProps.location.query.r ) || undefined,

--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -17,6 +17,7 @@ const Search = React.createClass( {
 	propTypes: {
 		defaultTLD: PropTypes.string.isRequired,
 		fetchDomainSuggestions: PropTypes.func.isRequired,
+		hasLoadedFromServer: PropTypes.bool.isRequired,
 		isRequesting: PropTypes.bool.isRequired,
 		numberOfResultsToDisplay: PropTypes.number,
 		query: PropTypes.string.isRequired,
@@ -155,9 +156,11 @@ const Search = React.createClass( {
 
 					<Suggestions
 						count={ this.props.numberOfResultsToDisplay }
+						hasLoadedFromServer={ this.props.hasLoadedFromServer }
 						results={ this.props.results }
 						selectDomain={ this.selectDomain }
-						sort={ this.props.sort } />
+						sort={ this.props.sort }
+					/>
 
 					{ showAdditionalResultsLink && (
 						<div className={ styles.additionalResultsLinkContainer }>

--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -140,3 +140,10 @@
 .logo {
 	padding: 30px;
 }
+
+.no-results-message {
+	color: $white;
+	font-size: 1.8rem;
+	margin-top: 50px;
+	text-align: center;
+}

--- a/app/components/ui/search/suggestions.js
+++ b/app/components/ui/search/suggestions.js
@@ -1,4 +1,5 @@
 // External dependencies
+import i18n from 'i18n-calypso';
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
@@ -17,6 +18,7 @@ const getNumberFromPrice = price => Number( price.replace( /[^0-9.]/g, '' ) );
 const Suggestions = React.createClass( {
 	propTypes: {
 		count: PropTypes.number,
+		hasLoadedFromServer: PropTypes.bool.isRequired,
 		results: PropTypes.array,
 		selectDomain: PropTypes.func.isRequired,
 		sort: PropTypes.string.isRequired
@@ -53,8 +55,16 @@ const Suggestions = React.createClass( {
 	},
 
 	render() {
-		if ( ! this.props.results ) {
+		if ( ! this.props.hasLoadedFromServer ) {
 			return null;
+		}
+
+		if ( this.props.hasLoadedFromServer && ! this.props.results.length ) {
+			return (
+				<div className={ styles.noResultsMessage }>
+					{ i18n.translate( "We couldn't find any domains. Try a different search." ) }
+				</div>
+			);
 		}
 
 		return (


### PR DESCRIPTION
Fixes #586. Requires D2718-code.

<img width="637" alt="screen shot 2016-09-02 at 4 30 42 pm" src="https://cloud.githubusercontent.com/assets/1130674/18217401/9e57804c-712a-11e6-8d01-b78a6c7cb69e.png">

This PR updates `Search` to display a message in the search area indicating that no search results were found, replacing the error notice that used to display here.

**Testing**
- Visit http://delphin.localhost:1337/search?q=ass
- Assert that you see the message in the screenshot above.
- Enter a query that returns suggestions (anything without profanity).
- Assert that the message in the screenshot above is replaced with search results.
- [x] Code
- [x] Product
- [ ] Design
