### PR TITLE
Replace .live domains with .blog domains

### DIFF
--- a/app/reducers/domain-search/index.js
+++ b/app/reducers/domain-search/index.js
@@ -13,8 +13,17 @@ const initialState = {
 	query: null
 };
 
+const replaceDotLiveWithDotBlog = results => {
+	return results && results.map( result => {
+		const dotBlogDomainName = result.domain_name.replace( /\.live/, '.blog' );
+
+		return Object.assign( {}, result, { domain_name: dotBlogDomainName } );
+	} );
+};
+
 export function domainSearch( state = initialState, action ) {
-	const { results, query, type } = action;
+	const { query, type } = action,
+		results = replaceDotLiveWithDotBlog( action.results );
 
 	switch ( type ) {
 		case DOMAIN_SUGGESTIONS_CLEAR:

--- a/app/reducers/domain-search/tests/index.js
+++ b/app/reducers/domain-search/tests/index.js
@@ -32,7 +32,10 @@ describe( 'domain search reducer', () => {
 		const originalState = Object.freeze( {
 				hasLoadedFromServer: false,
 				isRequesting: false,
-				results: [ 'example1.com', 'example2.com' ],
+				results: [
+					{ domain_name: 'example1.com' },
+					{ domain_name: 'example2.com' }
+				],
 				query: 'example'
 			} ),
 			newState = domainSearch( originalState, {} );
@@ -44,7 +47,10 @@ describe( 'domain search reducer', () => {
 		const originalState = Object.freeze( {
 				hasLoadedFromServer: false,
 				isRequesting: false,
-				results: [ 'example1.com', 'example2.com' ],
+				results: [
+					{ domain_name: 'example1.com' },
+					{ domain_name: 'example2.com' }
+				],
 				query: 'example'
 			} ),
 			newState = domainSearch( originalState, { type: 'ORDER_CHEESE_BURGER' } );
@@ -71,7 +77,10 @@ describe( 'domain search reducer for domain suggestions clear action', () => {
 		const originalState = Object.freeze( {
 				hasLoadedFromServer: false,
 				isRequesting: true,
-				results: [ 'example1.com', 'example2.com' ],
+				results: [
+					{ domain_name: 'example1.com' },
+					{ domain_name: 'example2.com' }
+				],
 				query: 'example'
 			} ),
 			newState = domainSearch( originalState, {
@@ -105,7 +114,10 @@ describe( 'domain search reducer for domain suggestions fetch action', () => {
 	it( 'should clear the results when fetching', () => {
 		const originalState = Object.freeze( {
 				isRequesting: false,
-				results: [ 'example1.com', 'example2.com' ],
+				results: [
+					{ domain_name: 'example1.com' },
+					{ domain_name: 'example2.com' }
+				],
 				query: 'example'
 			} ),
 			newState = domainSearch( originalState, {
@@ -130,7 +142,7 @@ describe( 'domain search reducer for domain suggestions fetch completed action',
 			isRequesting: true,
 			query: 'example'
 		}, {
-			results: [ 'example.com' ],
+			results: [ { domain_name: 'example.com' } ],
 			type: DOMAIN_SUGGESTIONS_FETCH_COMPLETE,
 			query: 'example'
 		} );
@@ -138,7 +150,7 @@ describe( 'domain search reducer for domain suggestions fetch completed action',
 		expect( newState ).toEqual( {
 			hasLoadedFromServer: true,
 			isRequesting: false,
-			results: [ 'example.com' ],
+			results: [ { domain_name: 'example.com' } ],
 			query: 'example'
 		} );
 	} );
@@ -147,15 +159,40 @@ describe( 'domain search reducer for domain suggestions fetch completed action',
 		const originalState = Object.freeze( {
 				hasLoadedFromServer: false,
 				isRequesting: true,
-				results: [ 'example1.com', 'example2.com' ],
+				results: [
+					{ domain_name: 'example1.com' },
+					{ domain_name: 'example2.com' }
+				],
 				query: 'example'
 			} ),
 			newState = domainSearch( originalState, {
-				results: [ 'foobar.com' ],
+				results: [ { domain_name: 'foobar.com' } ],
 				type: DOMAIN_SUGGESTIONS_FETCH_COMPLETE,
 				query: 'foobar'
 			} );
 
 		expect( newState ).toEqual( originalState );
+	} );
+} );
+
+describe( 'domain search reducer rewriting .live to .blog', () => {
+	it( 'should return .blog domains when provided with .live domains', () => {
+		const newState = domainSearch( {
+			results: null,
+			hasLoadedFromServer: false,
+			isRequesting: true,
+			query: 'example'
+		}, {
+			results: [ { domain_name: 'example.live' } ],
+			type: DOMAIN_SUGGESTIONS_FETCH_COMPLETE,
+			query: 'example'
+		} );
+
+		expect( newState ).toEqual( {
+			hasLoadedFromServer: true,
+			isRequesting: false,
+			results: [ { domain_name: 'example.blog' } ],
+			query: 'example'
+		} );
 	} );
 } );


### PR DESCRIPTION
This pull request replaces `.live` with `.blog` in the search results on /search. This means we can provide users with additional suggestions to their initial search.
#### Testing instructions
1. Run `git checkout update/blog-domains` and start your server, or open a [live branch](https://delphin.live/?branch=update/blog-domains)
2. Open the [`Search` page](http://delphin.localhost:1337/search)
3. Check that the results return `.blog` addresses not `.live`.
#### Reviews
- [ ] Code
- [ ] Product
- [ ] Tests

@Automattic/sdev-feed
