### PR TITLE
Fetch the domain price when logging in with 2FA

### DIFF
--- a/app/components/containers/connect-user/verify.js
+++ b/app/components/containers/connect-user/verify.js
@@ -10,6 +10,7 @@ import { getAsyncValidateFunction } from 'lib/form';
 import { getSelectedDomain, hasSelectedDomain } from 'reducers/checkout/selectors';
 import { getPath } from 'routes';
 import { getUserConnect, isLoggedIn } from 'reducers/user/selectors';
+import { fetchDomainPrice } from 'actions/domain-price';
 import { recordPageView } from 'actions/analytics';
 import { redirect } from 'actions/routes';
 import { selectDomain } from 'actions/domain-search';
@@ -52,6 +53,7 @@ export default reduxForm(
 		addNotice,
 		connectUser,
 		connectUserComplete,
+		fetchDomainPrice,
 		redirectToTryWithDifferentEmail: withAnalytics( recordTracksEvent( 'delphin_try_different_email_click' ), () => thunkDispatch => {
 			thunkDispatch( clearConnectUser() );
 			thunkDispatch( redirect( 'signupUser' ) );

--- a/app/components/ui/connect-user/verify-user/index.js
+++ b/app/components/ui/connect-user/verify-user/index.js
@@ -20,6 +20,7 @@ const VerifyUser = React.createClass( {
 		connectUserComplete: PropTypes.func.isRequired,
 		domain: PropTypes.object,
 		errors: PropTypes.object,
+		fetchDomainPrice: PropTypes.func.isRequired,
 		fields: PropTypes.object.isRequired,
 		handleSubmit: PropTypes.func.isRequired,
 		hasSelectedDomain: PropTypes.bool.isRequired,
@@ -49,7 +50,9 @@ const VerifyUser = React.createClass( {
 
 		if ( this.isUsingCodeFromQuery() ) {
 			if ( query.domain ) {
-				this.props.selectDomain( { domainName: query.domain } );
+				this.props.fetchDomainPrice( query.domain ).then( action => {
+					this.props.selectDomain( action.result );
+				} );
 			}
 
 			// the sign-in email directs the user to this component only if two factor authentication is enabled


### PR DESCRIPTION
This PR fixes an issue that causes checkout to fail when logging in to an account that has 2FA. The domain price was not fetched in this flow.

**Testing**
- Visit `/` and enter/submit a domain name.
- Proceed until you need to sign up/in.
- Enter an email address for an account with 2FA enabled.
- Submit.
- Click the 'Claim your domain' link in the email you are sent.
- Enter your 2FA code in the form that appears.
- Submit.
- Assert that you can complete checkout from this point.
- [x] Code
- [ ] Product
