### PR TITLE
My domains: Add an error when the fetch fails

### DIFF
--- a/app/actions/my-domains.js
+++ b/app/actions/my-domains.js
@@ -1,4 +1,5 @@
 // Internal dependencies
+import { addNotice } from 'actions/notices';
 import {
 	MY_DOMAINS_FETCH,
 	MY_DOMAINS_FETCH_COMPLETE,
@@ -23,8 +24,15 @@ export const fetchMyDomains = () => ( {
 		type: MY_DOMAINS_FETCH_COMPLETE,
 		results
 	} ),
-	fail: error => dispatch => dispatch( {
-		type: MY_DOMAINS_FETCH_FAIL,
-		error
-	} )
+	fail: error => dispatch => {
+		dispatch( {
+			type: MY_DOMAINS_FETCH_FAIL,
+			error
+		} );
+
+		dispatch( addNotice( {
+			message: error.message,
+			status: 'error'
+		} ) );
+	}
 } );


### PR DESCRIPTION
This pull request adds a notice when the list of domains fails to load.

To test this you will need to add an error to the purchases fetch endpoint, like this: 15d8e-pb

<img width="857" alt="screen shot 2016-09-08 at 12 02 28" src="https://cloud.githubusercontent.com/assets/275961/18347203/28925f08-75bc-11e6-9184-b11add3bdeb7.png">
#### Testing instructions
1. Log in from http://delphin.localhost:1337/log-in
2. Click on the `My domains` link in the footer
3. Wait for the endpoint to fail to load and look for the failure notice
#### Additional notes

This adds a commit which allows users to log in without selecting a domain, and a "My Domains" link to the footer. This should be removed before merging.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed 
