### PR TITLE
Disable source-maps for the RTL build

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -54,9 +54,11 @@ var config = {
 	// Enables source maps both for the client and server.
 	// - In development this property might be overridden to make debugging easier/faster.
 	// - This is required in production to be able to debug client-side errors more easily.
-	// Note however that source maps won't be used server-side in production since we serve static pages,
-	// in this case it's only useful for the dev server.
-	devtool: 'source-map',
+	// Note:
+	// - Source maps won't be used server-side in production since we serve static pages.
+	// - Source maps are disabled for the RTL build in production to keep the
+	//   size of our diffs down.
+	devtool: process.env.NODE_ENV === 'production' && process.env.BUILD_RTL ? undefined : 'source-map',
 
 	plugins: [
 		new webpack.DefinePlugin( {

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -41,7 +41,7 @@ var config = merge.smart( baseConfig, {
 		publicPath: '/scripts/',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 		filename: process.env.BUILD_RTL ? 'bundle.rtl.[hash].js' : 'bundle.[hash].js',
-		sourceMapFilename: 'bundle.[hash].map.js'
+		sourceMapFilename: process.env.BUILD_RTL ? 'bundle.rtl.[hash].map.js' : 'bundle.[hash].map.js'
 	},
 
 	plugins: [


### PR DESCRIPTION
Sourcemaps are large (>10MB). We ship them in production because they are used by Sentry, but they make our deploy diffs huge.

We'll eventually need a more robust solution here, even without RTL, but in the meantime we can just disable sourcemaps for the RTL build in production.

**Testing**
- Run `npm run start:static`
- Assert that no RTL sourcemap was created:

``` bash
delphin (remove/rtl-sourcemaps) ☯ ls -lrt public/scripts/
total 26520
-rw-r--r--  1 drewblaisdell  staff  10279410 Sep  8 14:55 bundle.4d5b1eb7b143752b9320.map.js
-rw-r--r--  1 drewblaisdell  staff   1643148 Sep  8 14:55 bundle.4d5b1eb7b143752b9320.js
-rw-r--r--  1 drewblaisdell  staff   1643118 Sep  8 14:56 bundle.rtl.65ecc68ccea641d1519d.js
-rw-r--r--  1 drewblaisdell  staff        45 Sep  8 14:56 assets.json
```
