### PR TITLE
Search: Update header design on small screens

### DIFF
--- a/app/components/ui/header/styles.scss
+++ b/app/components/ui/header/styles.scss
@@ -21,6 +21,15 @@
 	right: 0;
 	top: 0;
 	z-index: 1;
+
+	@include breakpoint( '<660px' ) {
+		flex-direction: column-reverse;
+		height: auto;
+	}
+
+	@include breakpoint( '<480px' ) {
+		position: static;
+	}
 }
 
 .logo {

--- a/app/components/ui/search-input/styles.scss
+++ b/app/components/ui/search-input/styles.scss
@@ -1,5 +1,6 @@
 @import 'app/styles/colors';
 @import 'app/styles/fonts';
+@import 'app/styles/breakpoints';
 
 .search-wrapper {
 	border: 0;
@@ -21,11 +22,25 @@
 		padding: 3px;
 		vertical-align: top;
 		width: 100%;
+
+		@include breakpoint( '<660px' ) {
+			font-size: 16px;
+			margin-top: 5px;
+			padding: 10px 3px;
+		}
+	}
+
+	@include breakpoint( '<660px' ) {
+		flex-direction: column;
 	}
 }
 
 .keywords {
 	display: flex;
+
+	@include breakpoint( '<660px' ) {
+		flex-wrap: wrap;
+	}
 }
 
 .keyword {
@@ -41,6 +56,10 @@
 	position: relative;
 	user-select: none;
 	white-space: nowrap;
+
+	@include breakpoint( '<660px' ) {
+		margin-bottom: 5px;
+	}
 }
 
 .keyword-action {

--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -111,11 +111,18 @@
 .sort {
 	color: rgba( $white, 0.7 );
 	font-size: 1.6rem;
-	margin-top: 83px;
+	margin-top: 150px;
 	padding: 10px 20px;
 
 	@include breakpoint( '>660px' ) {
 		font-size: 1.6rem;
+		margin-top: 83px;
+	}
+
+	@include breakpoint( '<480px' ) {
+		font-size: 1.4rem;
+		margin-top: 0;
+		padding: 10px;
 	}
 }
 
@@ -140,6 +147,10 @@
 		background: $white;
 		color: $blue-dark;
 	}
+
+	@include breakpoint( '<480px' ) {
+		font-size: 1.4rem;
+	}
 }
 
 .search-info {
@@ -152,7 +163,11 @@
 }
 
 .logo {
-	padding: 30px;
+	padding: 30px 30px 30px 10px;
+
+	@include breakpoint( '<660px' ) {
+		padding: 15px 10px 5px;
+	}
 }
 
 .no-results-message {


### PR DESCRIPTION
This fixes #625 by reorganizing some elements in the header on small screens.

| Before | After |
| --- | --- |
| <img width="319" alt="screen shot 2016-09-08 at 15 47 17" src="https://cloud.githubusercontent.com/assets/448298/18364368/110ba248-75dc-11e6-8f1b-9a284951204a.png"> | <img width="319" alt="screen shot 2016-09-08 at 15 42 17" src="https://cloud.githubusercontent.com/assets/448298/18364379/17024008-75dc-11e6-9323-393dca9ccaf2.png"> |
| <img width="318" alt="screen shot 2016-09-08 at 15 47 46" src="https://cloud.githubusercontent.com/assets/448298/18364387/1dd4461a-75dc-11e6-8191-e13086897c0e.png"> | <img width="318" alt="screen shot 2016-09-08 at 15 39 58" src="https://cloud.githubusercontent.com/assets/448298/18364391/2204298a-75dc-11e6-8159-2cd8c9203f4f.png"> |

Because the logo, keywords, and input are stacked it makes it quite tall. To help remedy that I removed the fixed position at `<480px` so the header scrolls out of view. Ideally I'd like to see it slide up then slide down when the user starts scrolling back up, but maybe we'll push that to M3.

**Review**
- [x] Design
- [ ] Code
