### PR TITLE
Search: Fix long keywords display bug in Safari

### DIFF
--- a/app/components/ui/search-input/keywords.js
+++ b/app/components/ui/search-input/keywords.js
@@ -12,7 +12,7 @@ function Keywords( props ) {
 	}
 
 	return (
-		<span>
+		<span className={ styles.keywordsWrapper }>
 			<ul className={ styles.keywords }>
 				{ props.keywords.map( keyword => (
 					<KeywordContainer

--- a/app/components/ui/search-input/styles.scss
+++ b/app/components/ui/search-input/styles.scss
@@ -24,6 +24,10 @@
 	}
 }
 
+.keywords-wrapper {
+	flex-shrink: 0;
+}
+
 .keywords {
 	display: flex;
 }
@@ -34,10 +38,11 @@
 	border-radius: 5px;
 	color: #fff;
 	cursor: pointer;
+	flex-shrink: 0;
 	font-size: 15px;
 	line-height: 21px;
 	margin-right: 5px;
-	padding: 5px 40px 5px 10px;
+	padding: 5px 30px 5px 10px;
 	position: relative;
 	user-select: none;
 	white-space: nowrap;


### PR DESCRIPTION
Fixes #260. Test in Safari by adding a long term to the search input.

| Before | After |
| --- | --- |
| <img width="555" alt="screen shot 2016-09-08 at 16 14 23" src="https://cloud.githubusercontent.com/assets/448298/18365508/f5f60750-75e0-11e6-93ad-cf8a9f0bac00.png"> | <img width="555" alt="screen shot 2016-09-08 at 16 21 00" src="https://cloud.githubusercontent.com/assets/448298/18365499/f1b24bcc-75e0-11e6-90fb-0f2fdb42efb6.png"> |

**Review**
- [x] Product
- [x] Code
