### PR TITLE
Search: Fix thin fonts on search results

### DIFF
--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -203,5 +203,5 @@
 
 .application-fee-message {
 	color: $gray;
-	font-weight: 200;
+	font-weight: 300;
 }


### PR DESCRIPTION
The search results application fee had a `200` font-weight that caused it to be too thin in Safari. This fixes it.

| Before | After |
| --- | --- |
| <img width="379" alt="screen shot 2016-09-08 at 16 29 44" src="https://cloud.githubusercontent.com/assets/448298/18365836/3e59de6c-75e2-11e6-9bdc-dc40c4d33ffe.png"> | <img width="380" alt="screen shot 2016-09-08 at 16 30 58" src="https://cloud.githubusercontent.com/assets/448298/18365835/3a6d9f32-75e2-11e6-9209-e671605506eb.png"> |
