### PR TITLE
Fix: Home: Validation on load

### DIFF
--- a/app/components/ui/sunrise-home/index.js
+++ b/app/components/ui/sunrise-home/index.js
@@ -31,7 +31,7 @@ const SunriseHome = React.createClass( {
 		// Trigger validation if we have an initialValue for query
 		if ( query.initialValue ) {
 			this.props.touch( query.name );
-			this.props.asyncValidate();
+			this.props.handleSubmit( () => null )();
 		}
 	},
 


### PR DESCRIPTION
This PR changes how we validate the form on SunriseHome load by calling `handleSubmit` directly instead of `asyncValidate` which is an internal function of `redux-form` and should not be called from our components!
`asyncValidate` is allowed to return a rejected promise and `redux-form` is made to catch this (as to stop the propagation) in `handleSubmit`. 
### Testing Instructions
- `git checkout master && npm start`
- Go to http://delphin.localhost:1337/?query=r and assert that an error is visible in the console
- `git checkout fix/form-unhandledrejection && npm start`
- Go to http://delphin.localhost:1337/?query=r and assert that the error is not visible anymore
- Form validation should still work without any problem, displaying an error on the input field.
### Reviews
- [x] Code
- [x] Product
