### PR TITLE
Add the application fee to the search results page

### DIFF
--- a/app/components/ui/search/suggestion.js
+++ b/app/components/ui/search/suggestion.js
@@ -19,7 +19,8 @@ const Suggestion = React.createClass( {
 	},
 
 	render() {
-		const cost = find( this.props.suggestion.details, { productSlug: 'delphin-domain' } ).cost;
+		const domainDetails = find( this.props.suggestion.details, { productSlug: 'delphin-domain' } ),
+			{ cost, applicationFee } = domainDetails;
 
 		return (
 			<li className={ styles.suggestion } onClick={ this.selectDomain }>
@@ -37,7 +38,9 @@ const Suggestion = React.createClass( {
 						} ) }
 					</div>
 					<div className={ styles.applicationFeeMessage }>
-						{ i18n.translate( '+ early application fee' ) }
+						{ i18n.translate( '+ %(applicationFee)s early application fee', {
+							args: { applicationFee }
+						} ) }
 					</div>
 				</div>
 				<div className={ styles.buyButton }>


### PR DESCRIPTION
Requires D2809-code.

This pull request fixes #614 by adding the application fee to the search results page like this:

![Screenshot](https://cloud.githubusercontent.com/assets/426518/18349104/1b0eaa1e-75d8-11e6-8df4-f57bfb60ef0a.png)
#### Testing instructions
1. Run `git checkout add/application-fee` and start your server, or open a [live branch](https://delphin.live/?branch=add/application-fee)
2. Open the [`Search` page](http://delphin.localhost:1337/?q=testing)
3. Check that the application fee appears underneath each suggestion
#### Additional notes

We can probably remove the domain price endpoint altogether now, but we should do it in a different PR.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
