### PR TITLE
Prevent search requests that contain no alphanumeric characters

### DIFF
--- a/app/actions/domain-search.js
+++ b/app/actions/domain-search.js
@@ -18,7 +18,7 @@ import {
 	DOMAIN_SUGGESTIONS_FETCH_FAIL,
 	DOMAIN_UNSELECT,
 } from 'reducers/action-types';
-import { omitTld } from 'lib/domains';
+import { containsAlphanumericCharacters, omitTld } from 'lib/domains';
 
 /**
  * Returns an action object to be used in signalling that domain suggestions have been cleared.
@@ -32,7 +32,7 @@ export function clearDomainSuggestions() {
 }
 
 export function fetchDomainSuggestions( domainQuery = '' ) {
-	if ( domainQuery.trim() === '' ) {
+	if ( ! containsAlphanumericCharacters( domainQuery ) ) {
 		return clearDomainSuggestions();
 	}
 

--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -7,7 +7,7 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 // Internal dependencies
 import config from 'config';
 import DocumentTitle from 'components/ui/document-title';
-import { isDomainSearch, isValidSecondLevelDomain, queryIsInResults } from 'lib/domains';
+import { containsAlphanumericCharacters, isDomainSearch, isValidSecondLevelDomain, queryIsInResults } from 'lib/domains';
 import styles from './styles.scss';
 import Suggestions from './suggestions';
 import SearchHeader from './header';
@@ -159,6 +159,12 @@ const Search = React.createClass( {
 						) }
 
 					</div>
+
+					{ query && ! containsAlphanumericCharacters( query ) && (
+						<div className={ styles.noResultsMessage }>
+							{ i18n.translate( "We couldn't find any domains. Try a different search." ) }
+						</div>
+					) }
 
 					<Suggestions
 						count={ this.props.numberOfResultsToDisplay }

--- a/app/lib/domains/index.js
+++ b/app/lib/domains/index.js
@@ -92,6 +92,15 @@ export const withTld = ( domain = '', tld = config( 'default_tld' ) ) => domain.
 const reservedDomains = [ 'get', 'nic', 'dave', 'design', 'blacknight', 'matt' ];
 
 /**
+ * Determines if the given query contains at least one alphanumeric character.
+ *
+ * @param {string} query - A search query
+ * @return {boolean} - A flag representing whether the given query contains at
+ * least one alphanumeric character.
+ */
+export const containsAlphanumericCharacters = query => query.replace( /\W+/g, '' ).length > 0;
+
+/**
  * Returns validation messages for the given domain.
  *
  * @param {string} domain - domain to validate.


### PR DESCRIPTION
Fixes #590.

![screen shot 2016-09-09 at 1 38 30 pm](https://cloud.githubusercontent.com/assets/1130674/18396946/055ceab6-7694-11e6-8172-ca7ffb45c0dd.png)

This PR updates `Search` to:
- Not make requests to the suggestions endpoint if the query does not contain any alphanumeric characters. The API returns an error in this case and an error notice would be displayed otherwise.
- Display a message in the search area indicating that the user should enter search terms to see results.

**Testing**
- Visit `/search`.
- Enter a query that contains no alphanumeric characters (e.g. `?` or `#$@$@#$`).
- Assert that the message in the screenshot above appears and that no error notice is displayed.
- [x] Code
- [ ] Product
