### PR TITLE
Add initial cover images for hosts

### DIFF
--- a/app/components/ui/host-info/styles.scss
+++ b/app/components/ui/host-info/styles.scss
@@ -14,21 +14,26 @@
 }
 
 .header {
+	background-repeat: no-repeat;
+	background-size: cover;
 	color: $white;
 	margin-bottom: 20px;
 	padding: 30px;
 	text-align: center;
 
 	&.wordpress {
-		background: $host-wordpress;
+		background-color: $host-wordpress;
+		background-image: url( https://domainsearchproto.herokuapp.com/img/wordpress-bg.jpg );
 	}
 
 	&.medium {
-		background: $host-medium;
+		background-color: $host-medium;
+		background-image: url( https://domainsearchproto.herokuapp.com/img/medium-bg.jpg );
 	}
 
 	&.tumblr {
-		background: $host-tumblr;
+		background-color: $host-tumblr;
+		background-image: url( https://domainsearchproto.herokuapp.com/img/wordpress-bg.jpg );
 	}
 }
 


### PR DESCRIPTION
Adds cover images to host info to solve #233 .
Since we don't have final images yet, I've just linked the ones from the prototype

![screen shot 2016-09-12 at 9 28 59 am](https://cloud.githubusercontent.com/assets/326402/18426700/2335c1cc-78cc-11e6-92f0-370cdc727ec0.png)
#### Testing instructions
1. Run `git checkout add/host-cover` and start your server, or open a [live branch](https://delphin.live/?branch=add/host-cover)
2. Open the [`Hosts` page](http://delphin.localhost:1337/hosts)
3. Click some host, like [WordPress](http://delphin.localhost:1337/hosts/wordpress)
4. Assert there is a host image
#### Additional notes

Since the overall design and colors changed after creating that page we might want to address that in a separate PR.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
