### PR TITLE
Make search a route in production

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -13,6 +13,7 @@ import LearnMore from 'components/containers/learn-more';
 import LoginContainer from 'components/containers/connect-user/login';
 import NoMarginLayout from 'components/ui/layout/no-margin';
 import NotFound from 'components/ui/not-found';
+import SearchContainer from 'components/containers/search';
 import SignupContainer from 'components/containers/connect-user/signup';
 import SuccessContainer from 'components/containers/success';
 import SunriseConfirmDomainContainer from 'components/containers/sunrise-confirm-domain';
@@ -127,19 +128,16 @@ let publicRoutes = [
 				component: SuccessContainer
 			}
 		]
-	}
-];
-
-if ( ! process.env.NODE_ENV || process.env.NODE_ENV === 'development' ) {
-	const SearchContainer = require( 'components/containers/search' ).default;
-
-	publicRoutes.push( {
+	},
+	{
 		path: 'search',
 		slug: 'search',
 		static: true,
 		component: SearchContainer
-	} );
+	}
+];
 
+if ( ! process.env.NODE_ENV || process.env.NODE_ENV === 'development' ) {
 	const MyDomainsContainer = require( 'components/containers/my-domains' ).default;
 	const HostsContainer = require( 'components/containers/hosts' ).default;
 	const HostInfoContainer = require( 'components/containers/host-info' ).default;


### PR DESCRIPTION
The `/search` route wasn't part of the production routes, so when the user is redirected to it in production, they don't see the `/search` page.

To test, run this branch with `NODE_ENV=production`.
