### PR TITLE
Fix affordable sort option on Search page

### DIFF
--- a/app/components/ui/search/suggestions.js
+++ b/app/components/ui/search/suggestions.js
@@ -32,8 +32,8 @@ const Suggestions = React.createClass( {
 				unique: ( a, b ) => a.relevance - b.relevance,
 				short: ( a, b ) => a.domainName.length - b.domainName.length,
 				affordable: ( a, b ) => {
-					const costA = getNumberFromPrice( a.cost ),
-						costB = getNumberFromPrice( b.cost );
+					const costA = getNumberFromPrice( a.totalCost ),
+						costB = getNumberFromPrice( b.totalCost );
 
 					if ( costA > costB ) {
 						return 1;


### PR DESCRIPTION
This pull request fixes an error thrown when switching to the `affordable` sort option on the `Search` page:

![screenshot](https://cloud.githubusercontent.com/assets/594356/18434263/658cc596-78ec-11e6-904b-032a63064469.png)

The corresponding results would not be displayed in that case.
#### Testing instructions
1. Run `git checkout fix/affordable-domains` and start your server, or open a [live branch](https://delphin.live/?branch=fix/affordable-domains)
2. Open the [`Search` page](http://delphin.localhost:1337/search)
3. Check that you can display affordable domains
#### Reviews
- [x] Code
- [x] Product
- [ ] Tests

@Automattic/sdev-feed
