### PR TITLE
Disable autocomplete in /checkout

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -143,6 +143,7 @@ const Checkout = React.createClass( {
 						onSubmit={ handleSubmit( this.props.redirectToCheckoutReview ) }
 						errors={ errors }
 						focusOnError
+						autoComplete="off"
 					>
 						<Form.FieldArea>
 							<fieldset>

--- a/app/components/ui/form/index.js
+++ b/app/components/ui/form/index.js
@@ -9,8 +9,8 @@ import FieldArea from 'components/ui/form/field-area';
 import SubmitArea from 'components/ui/form/submit-area';
 import { withErrorFocuser } from 'components/ui/form/error-focuser';
 
-const Form = withErrorFocuser( withStyles( styles )( ( { children, onSubmit, className } ) => (
-	<form onSubmit={ onSubmit } className={ classNames( styles.form, className ) } noValidate>
+const Form = withErrorFocuser( withStyles( styles )( ( { children, onSubmit, className, autoComplete } ) => (
+	<form onSubmit={ onSubmit } className={ classNames( styles.form, className ) } noValidate autoComplete={ autoComplete }>
 		{ children }
 	</form>
 ) ) );


### PR DESCRIPTION
This pull request fixes #302 by disabling autocomplete on the checkout form.
#### Testing instructions
1. Run `git checkout add/autocomplte-disable` and start your server, or open a [live branch](https://delphin.live/?branch=add/autocomplte-disable)
2. Navigate to the /contact information form and check that you can still auto-complete it
3. Navigate to /checkout and check that autocomplete doesn't work.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
