### PR TITLE
Generate localized 404 files

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -124,12 +124,26 @@ const generateStaticFiles = rootRoutes => {
 		} );
 };
 
+const generateStatic404Files = () => {
+	config( 'languages' )
+		.filter( language => language.isRtl === BUILD_RTL )
+		// we filter out `en` because it lives in the top-level static directory, not under `/en/`
+		.filter( language => language.langSlug !== config( 'i18n_default_locale_slug' ) )
+		.map( language => `/${ language.langSlug }/404` )
+		.forEach( generateStaticFile );
+
+	if ( ! BUILD_RTL ) {
+		// generate English 404
+		generateStaticFile( '404' );
+	}
+};
+
 const init = () => {
 	if ( process.env.BUILD_STATIC ) {
 		generateStaticFiles( defaultRoutes );
 
-		// we need to explicitly generate a 404 page because it isn't in in the default routes
-		generateStaticFile( '404' );
+		// we need to explicitly generate 404 pages because 404 isn't in in the default routes
+		generateStatic404Files();
 
 		generateSourceMap();
 


### PR DESCRIPTION
Fixes #600 on the client. The rest will be fixed with this patch: D2835-code.

In order to serve localized 404 files, we need to generate a 404 file for each language. This PR updates the static build process to generate these.

**Testing**
- Run `npm run start:static`.
- Once the server starts, assert that the static 404 files have been built by visiting:
  - `/404` and asserting that an LTR, English 404 page is displayed.
  - `/fr/404` and asserting that an LTR, French 404 page is displayed.
  - `/he/404` and asserting that an RTL, Hebrew 404 page is displayed.
- [x] Code
- [x] Product
