### PR TITLE
Pass correct `id` property in the user actions

### DIFF
--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -101,12 +101,12 @@ export function fetchUser() {
 		params: { path: '/me' },
 		loading: FETCH_USER,
 		success: withAnalytics(
-					data => identifyUser( data.ID, data.username ),
+					data => identifyUser( data.id, data.username ),
 					( data, requestArguments, requestToken ) => ( {
 						type: FETCH_USER_COMPLETE,
 						bearerToken: requestToken,
 						email: data.email,
-						id: data.ID,
+						id: data.id,
 						language: data.language
 					} )
 				),


### PR DESCRIPTION
We started camelizing all keys from WPCOM in https://github.com/Automattic/delphin/commit/7516ba58898115aac0b5c1330069cff7ea25b1d5#diff-9d4893f942eaad63441c6dcae8648099 but did not update an instance where we access one of these un-camelized properties (`ID` instead of `id`), which broke the identify event when signing in.

**Note:** Circle fails for this branch intentionally to remind me to undo the changes to `config`.

**Testing**
- Execute `localStorage.setItem( 'debug', 'delphin:analytics' );` in your console.
- Visit `/`
- Proceed through the pre-reg flow with the console open.
- Assert that `delphin:analytics Identifying user with id: [some number] and username: [some string]` is logged to the console after logging in.
- [x] Code
- [x] Product

cc @lucasartoni 
