### PR TITLE
Fix Webpack failing because of breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "superagent-jsonp": "^0.1.1",
     "svg-react-loader": "^0.3.5",
     "validator": "^5.2.0",
-    "webpack": "^2.1.0-beta.22",
+    "webpack": "2.1.0-beta.22",
     "webpack-dev-server": "^2.1.0-beta.4",
     "webpack-merge": "^0.12.0",
     "wpcom-xhr-request": "^1.0.0"


### PR DESCRIPTION
This pull request fixes the following startup error:

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'debug'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   The 'debug' property was removed in webpack 2.
   Loaders should be updated to allow passing this option via loader options in module.rules.
   Until loaders are updated one can use the LoaderOptionsPlugin to switch loaders into debug mode:
   plugins: {
     new webpack.LoaderOptionsPlugin({
       debug: true
     })
   }
 - configuration.resolve.extensions[0] should not be empty.
```

A breaking change was indeed introduced in Webpack in [version 2.1.0-beta.23](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.23). This pull request makes sure we target the prior version by removing [the caret](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) in `package.json`. This [article](http://bytearcher.com/articles/semver-explained-why-theres-a-caret-in-my-package-json/) gives a good overview of this feature which allow a dependency to be updated to the most recent _minor_ or _patch level_ version.
#### Testing instructions
1. Run `git checkout update/webpack`
2. Clean the project with `npm clean:all`
3. Execute `npm start`
4. Check that the server starts and that you can access Delphin
#### Reviews
- [x] Code
- [ ] Product

@Automattic/sdev-feed
