### PR TITLE
Persist bearer token to cookie in development

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -33,11 +33,14 @@ const middlewares = [
 	adTrackingMiddleware,
 	analyticsMiddleware,
 	logErrorNoticesMiddleware,
-	userMiddleware,
 	wpcomMiddleware,
 	relatedWordsMiddleware,
 	switchLocaleMiddleware,
 ];
+
+if ( ! process.env.NODE_ENV || process.env.NODE_ENV === 'development' ) {
+	middlewares.push( userMiddleware );
+}
 
 const isDevelopment = 'production' !== config( 'env' );
 


### PR DESCRIPTION
This PR reverts 9d7487ac47eaf6fb10d6a7ffc72f94ac05242efe and updates `client/index` to only mount `userMiddleware` in development.

**Testing**
_Development_
- Click `Log in` in the footer.
- Log in.
- Visit `/` in a separate tab.
- Assert that you are still logged in.

_Production_
- Run `npm run start:static`
- Visit `/` when the server starts.
- Submit a query and proceed until you log in.
- Visit `/` in a separate tab.
- Assert that you are not logged in by proceeding through the pre-reg flow and asserting that you are asked to log in after submitting from `/confirm-domain`.
- [ ] Code
- [ ] Product
