### PR TITLE
Fix sitemap referencing English routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ import thunk from 'redux-thunk';
 import api from './wpcom-rest-api-proxy';
 import config, { isEnabled } from 'config';
 import { fileExists } from './utils';
-import generateSourceMap from './sitemap-generator';
+import generateSiteMap from './sitemap-generator';
 import i18nCache from './i18n-cache';
 import { getPath, defaultRoutes, routes } from 'app/routes';
 import { getLocaleSlug } from 'lib/routes';
@@ -145,7 +145,7 @@ const init = () => {
 		// we need to explicitly generate 404 pages because 404 isn't in in the default routes
 		generateStatic404Files();
 
-		generateSourceMap();
+		generateSiteMap();
 
 		// No need to start the server
 		return;

--- a/server/sitemap-generator.js
+++ b/server/sitemap-generator.js
@@ -6,28 +6,28 @@ import SiteMap from 'react-router-sitemap';
 import config from 'app/config';
 import { routes } from 'app/routes';
 
-// exclude some paths
+// Builds a list of non-English locales to use in the regular expressions below
+const locales = config( 'languages' ).filter( language => {
+	return language.langSlug !== 'en';
+} ).map( language => {
+	return language.langSlug;
+} ).join( '|' );
+
+// Includes only very specific routes in the sitemap
 const filterConfig = {
-	isValid: false,
+	isValid: true,
 	rules: [
-		/\/contact-information/,
-		/\/confirm-domain/,
-		/\/verify/,
-		/\/checkout/,
-		/\/checkout-review/,
-		/\/testnest/,
-		/\/sign-in-with-email/,
-		/\/sign-up-with-email/,
-		/\/success/,
-		/\/log-in/,
-		/\/signup/,
-		/\/\*/
+		new RegExp( `^\/(${ locales })?$` ),
+		new RegExp( `^(?:\/(${ locales }))?\/learn-more$` ),
+		new RegExp( `^(?:\/(${ locales }))?\/search$` )
 	]
 };
 
-export default () => (
+export default () => {
+	console.log( 'sitemap.xml written' );
+
 	new SiteMap( routes )
 		.filterPaths( filterConfig )
 		.build( 'https://' + config( 'hostname' ) )
-		.save( path.join( __dirname, '..', 'public', 'static', 'sitemap.xml' ) )
-);
+		.save( path.join( __dirname, '..', 'public', 'static', 'sitemap.xml' ) );
+};


### PR DESCRIPTION
This pull request fixes the [`sitemap.xml`](https://get.blog/sitemap.xml) that lists routes prefixed with the English locale:

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
<url> <loc>https://get.blog/</loc> </url>
<url> <loc>https://get.blog/learn-more</loc> </url>
<url> <loc>https://get.blog/search</loc> </url>
<url> <loc>https://get.blog/en</loc> </url>
<url> <loc>https://get.blog/en/learn-more</loc> </url>
<url> <loc>https://get.blog/en/search</loc> </url>
```

It also makes sure new routes won't be included in this sitemap, and as such indexed by search engines, until they are **explicitly whitelisted**.
#### Testing instructions
1. Run `git checkout fix/sitemap`
2. Execute `npm run clean && npm run generate`
3. Check that the sitemap generated in `/public/static/sitemap.xml` is valid
#### Reviews
- [ ] Code
- [ ] Product
- [ ] Tests

@Automattic/sdev-feed
