### PR TITLE
Fix images not hosted on WordPress.com

### DIFF
--- a/app/components/ui/checkout/styles.scss
+++ b/app/components/ui/checkout/styles.scss
@@ -125,7 +125,7 @@
 	.icon {
 		animation-duration: 0.5s;
 		animation-name: bounceIn;
-		background: url( /images/checkout-error.svg );
+		background: url( https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/checkout-error.svg );
 		height: 46px;
 		margin: 0 auto;
 		width: 72px;

--- a/app/components/ui/search-input/related-words.js
+++ b/app/components/ui/search-input/related-words.js
@@ -76,7 +76,7 @@ class RelatedWords extends Component {
 
 							{ isGoogleTranslateAttributionVisible && (
 								<li className={ styles.googleTranslateAttribution }>
-									<img src="/images/powered-by-google-translate.png" height={ 18 } width={ 175 } alt="Google Translate" />
+									<img src="https://s0.wp.com/wp-content/themes/a8c/getdotblog/public/images/powered-by-google-translate.png" height={ 18 } width={ 175 } alt="Google Translate" />
 								</li>
 							) }
 						</ul>


### PR DESCRIPTION
This pull request fixes two images that are broken in production:

![screenshot](https://cloud.githubusercontent.com/assets/594356/18887437/6a33a808-84f4-11e6-89e4-401a52855dbf.png)
#### Testing instructions
1. Run `git checkout fix/images` and start your server, or open a [live branch](https://delphin.live/?branch=fix/images)
2. Open the [`Search` page](https://get.blog/fr/search) in a non-English language
3. Check that the Google Translate image is correctly displayed
#### Reviews
- [x] Code
- [ ] Product

@Automattic/sdev-feed
