### PR TITLE
Framework: Remove duplicate React from the bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "serve-static": "^1.10.2"
   },
   "dependencies": {
-    "@automattic/dops-components": "github:automattic/dops-components",
+    "@automattic/dops-components": "github:automattic/dops-components#update/react-dependency",
     "async": "^2.0.0-rc.3",
     "autoprefixer": "^6.3.6",
     "babel-core": "^6.7.4",


### PR DESCRIPTION
This PR updates [`dops-components`](https://github.com/Automattic/dops-components) to make React a peer dependency so it does not include its own version of React in our bundle.
### Testing Instructions
- `git checkout fix/duplicate-react`
- `rm -rf node_modules`
- `npm i`
- `npm run prod:static`

Check that the bundle size is smaller.

You can also use `webpack --profile --config webpack.client.config.js --json > stats.json` to generate webpack build stats and load the generated JSON file into a visualizer: https://chrisbateman.github.io/webpack-visualizer/
#### Before

![image](https://cloud.githubusercontent.com/assets/230230/18914426/63492a4c-858d-11e6-99b3-41f7929fbbc0.png)
#### After

![image](https://cloud.githubusercontent.com/assets/230230/18914433/6a9d13c6-858d-11e6-9c10-2e776b2aca5b.png)
### Reviews
- [x] Code
- [x] Product
