### PR TITLE
Fix how we match the css file from the list of assets

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,7 @@ function renderPage( props, localeData, isRtl = false ) {
 	const bundleFileName = typeof assets.app === 'string' ? assets.app : assets.app[ 0 ];
 	let stylesFileName;
 	if ( Array.isArray( assets.app ) ) {
-		stylesFileName = assets.app.filter( asset => ( isRtl ? /rtl\.css$/ : /[^ltr].css$/ ).test( asset ) ).shift();
+		stylesFileName = assets.app.filter( asset => ( isRtl ? /rtl\.css$/ : /[^rtl].css$/ ).test( asset ) ).shift();
 	}
 	const vendorFileName = typeof assets.vendor === 'string' ? assets.vendor : assets.vendor[ 0 ];
 	const CDN_PREFIX = process.env.CDN_PREFIX || '';


### PR DESCRIPTION
The default style bundle name format is simply `bundle.[contenthash].css` so a valid regex which matches it but not `bundle.[contenthash].rtl.css` would be `/[^rtl].css$/`.
### Reviews
- [ ] Code
