### PR TITLE
Re-enable sourcemaps in production

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -49,7 +49,7 @@ var config = {
 	},
 
 	// Enables source maps both for the client and server.
-	devtool: process.env.NODE_ENV === 'production' ? undefined : 'source-map',
+	devtool: 'source-map',
 
 	plugins: [
 		new webpack.LoaderOptionsPlugin( {


### PR DESCRIPTION
Sourcemaps have been disabled with the change in our ltr/rtl build. This PR re-enables it in production.
### Testing Instructions
- `git checkout fix/sourcemaps-2`
- `npm run prod:static`
- Check that a `bundle.[hash].map.js` file is generated and that all js files end with `//# sourceMappingURL=bundle.[hash].map.js` 
### Reviews
- [x] Code review
- [x] Product review
