### PR TITLE
Fix incorrect detection of stylesheets

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -65,10 +65,16 @@ function renderPage( props, localeData, isRtl = false ) {
 	const assets = JSON.parse( fs.readFileSync( path.join( 'public', bundlePath, 'assets.json' ) ) );
 	// `main` is an array of JS files after a hot update has been applied
 	const bundleFileName = typeof assets.app === 'string' ? assets.app : assets.app[ 0 ];
+
 	let stylesFileName;
 	if ( Array.isArray( assets.app ) ) {
-		stylesFileName = assets.app.filter( asset => ( isRtl ? /rtl\.css$/ : /[^rtl].css$/ ).test( asset ) ).shift();
+		stylesFileName = assets.app.filter( asset => (
+			asset.endsWith( '.css' )
+		) ).filter( asset => (
+			isRtl === asset.endsWith( '.rtl.css' )
+		) ).shift();
 	}
+
 	const vendorFileName = typeof assets.vendor === 'string' ? assets.vendor : assets.vendor[ 0 ];
 	const CDN_PREFIX = process.env.CDN_PREFIX || '';
 


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/delphin/pull/684 that fixes a wrong regular expression used to detect stylesheets for LTR languages. Note this regular expression happened to work by sheer luck and was misleading.
#### Testing instructions
1. Run `git checkout fix/stylesheets`
2. Execute `npm run clean:static`
3. Execute `npm run start:static`
4. Open the [`Home` page](http://delphin.localhost:1337/) of any LTR language
5. Check that you can see a link to the default stylesheet in the source:
   
   ```
   <link rel="stylesheet" href="/styles/bundle.19882e90b938422b783de40327b64e6d.css">
   ```
6. Open the `Home` page of any RTL language
7. Check that you can see a link to the RTL stylesheet in the source:
   
   ```
   <link rel="stylesheet" href="/styles/bundle.44e6aeddfa.rtl.css">
   ```
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
