### PR TITLE
Checkout: Duplicate purchase error

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -69,10 +69,12 @@ const Checkout = React.createClass( {
 	},
 
 	renderCheckoutError() {
-		let errorMessage = i18n.translate( 'We weren\'t able to process your payment.' );
+		let errorMessage = i18n.translate( "We weren't able to process your payment." );
 
-		if ( this.props.checkout.transaction.error.code === 'duplicate_purchase' ) {
-			errorMessage = this.props.checkout.transaction.error.message;
+		const { transaction } = this.props.checkout;
+
+		if ( transaction.error && transaction.error.code === 'duplicate_purchase' ) {
+			errorMessage = transaction.error.message;
 		}
 
 		return (


### PR DESCRIPTION
This pull request along with D2947-code fixes #680 by adding an error message in the case where the user is making a duplicate purchase.
#### Testing instructions
1. Apply the path: D2947-code
2. Log in to an account that has already made a purchase
3. Try to purchase the same domain that has already been purchased with this account
4. Check that you see this error message on checkout, after the processing message: `You have already purchased this product.`
#### Additional notes

Check the checkout still works as expected.
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
