### PR TITLE
Change body style according to route

### DIFF
--- a/app/components/ui/layout/index.js
+++ b/app/components/ui/layout/index.js
@@ -1,13 +1,33 @@
 // External dependencies
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import some from 'lodash/some';
 
 // Internal dependencies
 import NoticesContainer from 'components/containers/notices';
 import PulsingDot from 'components/containers/pulsing-dot';
 import styles from './styles.scss';
 
-const Layout = ( { children } ) => {
+const LIGHT_COMPONENT_SLUGS = {
+	learnMore: true
+};
+
+let lastBodyClass = null;
+const setBodyClass = ( className ) => {
+	// Avoid touching the DOM when unnecessary
+	if ( lastBodyClass === className ) {
+		return;
+	}
+
+	document.body.className = className;
+};
+
+const Layout = ( { routes, children } ) => {
+	const isLightRoute = some( routes, route => LIGHT_COMPONENT_SLUGS[ route.slug ] );
+
+	// Side effect to change body background color
+	setBodyClass( isLightRoute ? styles.light : styles.dark );
+
 	return (
 		<div className={ styles.layout }>
 			<PulsingDot />
@@ -20,7 +40,8 @@ const Layout = ( { children } ) => {
 };
 
 Layout.propTypes = {
-	children: PropTypes.node.isRequired
+	children: PropTypes.node.isRequired,
+	routes: PropTypes.array.isRequired
 };
 
 export default withStyles( styles )( Layout );

--- a/app/components/ui/layout/styles.scss
+++ b/app/components/ui/layout/styles.scss
@@ -2,10 +2,6 @@
 @import 'app/styles/colors';
 @import 'app/styles/breakpoints';
 
-body {
-	background: $blue-background;
-}
-
 h1,
 h2,
 h3,
@@ -20,6 +16,14 @@ h6 {
 	color: $blue-dark;
 	font-family: $body-font;
 	font-weight: 400;
+}
+
+.dark {
+	background: $blue-background;
+}
+
+.light {
+	background-color: $white;
 }
 
 a {

--- a/app/components/ui/layout/sunrise/flow.js
+++ b/app/components/ui/layout/sunrise/flow.js
@@ -1,10 +1,8 @@
 // External dependencies
 import React, { PropTypes } from 'react';
-import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
 import SunriseLayout from '.';
-import styles from './flow.scss';
 
 const SunriseFlowLayout = ( { children } ) => (
 	<SunriseLayout isFooterDark={ true }>
@@ -16,4 +14,4 @@ SunriseFlowLayout.propTypes = {
 	children: PropTypes.node.isRequired
 };
 
-export default withStyles( styles )( SunriseFlowLayout );
+export default SunriseFlowLayout;

--- a/app/components/ui/layout/sunrise/flow.scss
+++ b/app/components/ui/layout/sunrise/flow.scss
@@ -1,5 +1,0 @@
-@import 'app/styles/colors';
-
-body {
-	background-color: $white;
-}

--- a/app/components/ui/layout/sunrise/success.js
+++ b/app/components/ui/layout/sunrise/success.js
@@ -1,10 +1,8 @@
 // External dependencies
 import React, { PropTypes } from 'react';
-import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
 import SunriseLayout from '.';
-import styles from './success.scss';
 
 const SunriseSuccessLayout = ( { children } ) => (
 	<SunriseLayout>
@@ -16,4 +14,4 @@ SunriseSuccessLayout.propTypes = {
 	children: PropTypes.node.isRequired
 };
 
-export default withStyles( styles )( SunriseSuccessLayout );
+export default SunriseSuccessLayout;

--- a/app/components/ui/layout/sunrise/success.scss
+++ b/app/components/ui/layout/sunrise/success.scss
@@ -1,5 +1,0 @@
-@import 'app/styles/colors';
-
-body {
-	background-color: $blue-background;
-}


### PR DESCRIPTION
The `body` needs to be either dark or light in different routes, we can't just define
different `body` back-ground-color in each route's stylesheet since only one of them will work.

Before:
![screen shot 2016-10-05 at 10 40 28](https://cloud.githubusercontent.com/assets/326402/19105170/4d6643e8-8ae9-11e6-8fc2-5eb1d0834f53.png)

After:
![screen shot 2016-10-05 at 10 49 08](https://cloud.githubusercontent.com/assets/326402/19105184/637654f2-8ae9-11e6-87ef-baea3be7bed8.png)

This is basically the same as #709  with another approach.
#### Testing instructions
1. Run `git checkout fix2/learn-more` and start your server, or open a [live branch](https://delphin.live/?branch=fix2/learn-more)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Visit different routes with different layouts, such as: Success page, home page and learn more
4. Assert that the background is dark except for learn more in which it is light.
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
