### PR TITLE
Start registering domains for Delphin 

### DIFF
--- a/app/actions/checkout.js
+++ b/app/actions/checkout.js
@@ -109,7 +109,7 @@ export function createTransaction() {
 			payment_method: 'paygate',
 			locale: 'en',
 			contact_information: snakeifyKeys( contactInformationForm ),
-			application_type: config( 'application_type' )
+			type: config( 'transaction_type' )
 		};
 
 		return dispatch( {

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -5,7 +5,7 @@ const NODE_ENV = process.env.NODE_ENV,
 	productionOnly = NODE_ENV === 'production';
 
 const config = {
-	application_type: 'pre_reg',
+	transaction_type: 'application',
 	available_tlds: [ 'blog' ],
 	default_tld: 'blog',
 	default_search_sort: 'recommended',


### PR DESCRIPTION
This will start attempting to register domains for Delphin transactions when the `application_type` is not set to `pre_reg`. At the moment it won't work because OpenSRS won't let us register .blog domains.
#### Testing instructions
1. Apply this patch: D2954-code
2. Restart npm start
3. Attempt to apply for a domain and check that everything works as before
4. Update your config value for `application_type` to `not_pre_reg`
5. Restart npm start
6. Attempt to apply for a domain and assert that you see an error on checkout.
7. Look at the transactions endpoint in your console - the error should be `oSRS Error Code #465: Registration not allowed under this TLD`
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
