### PR TITLE
Create artificat on any branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 deployment:
   production:
-    branch: master
+    branch: /.*/
     commands:
       - CDN_PREFIX=https://s0.wp.com/wp-content/themes/a8c/getdotblog/public npm run prod:static
       - tar cvzf $CIRCLE_ARTIFACTS/public.tar.gz -C public .


### PR DESCRIPTION
This pull request modifies CircleCI config in order for CircleCI to create artifact for every branch, not just `master`, so it could be later used to deploy to staging.

Related to D2953
#### Testing instructions

Validate that branch creates a build artifact unlike other branches via:

`./get-circle-ci-artifact-url <token> delphin update/create_artificat_on_any_branch`
#### Reviews
- [ ] Code
- [ ] Product

@Automattic/sdev-feed
