### PR TITLE
Set CDN prefix based on the current browser host

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -9,6 +9,8 @@ const config = {
 	default_tld: 'blog',
 	default_search_sort: 'recommended',
 	env: NODE_ENV || 'development',
+	staging_cdn_prefix: 'https://s0.wp.com/wp-content/themes/a8c/getdotblogstaging/public',
+	production_cdn_prefix: 'https://s0.wp.com/wp-content/themes/a8c/getdotblog/public',
 	google_conversion_id: 881304566,
 	google_conversion_label: 'WLR1CIHt3WkQ9seepAM',
 	hostname: 'get.blog',

--- a/circle.yml
+++ b/circle.yml
@@ -2,5 +2,5 @@ deployment:
   production:
     branch: master
     commands:
-      - CDN_PREFIX=https://s0.wp.com/wp-content/themes/a8c/getdotblog/public npm run prod:static
+      - npm run prod:static
       - tar cvzf $CIRCLE_ARTIFACTS/public.tar.gz -C public .

--- a/client/index.js
+++ b/client/index.js
@@ -28,6 +28,16 @@ import { switchLocaleMiddleware } from './switch-locale-middleware';
 import { userMiddleware } from './user-middleware';
 import { provideStore, sections } from 'sections';
 
+// Set the public path based on the current environment
+let cdnPrefix = '';
+if ( window.location.host.indexOf( 'getdotblogstaging' ) > -1 ) {
+	cdnPrefix = config( 'staging_cdn_prefix' );
+} else if ( window.location.host.indexOf( 'get.blog' ) > -1 ) {
+	cdnPrefix = config( 'production_cdn_prefix' );
+}
+
+__webpack_public_path__ = cdnPrefix + '/scripts/'; // eslint-disable-line
+
 const middlewares = [
 	routerMiddleware( browserHistory ),
 	thunk,

--- a/server/index.js
+++ b/server/index.js
@@ -76,7 +76,6 @@ function renderPage( props, localeData, isRtl = false ) {
 	}
 
 	const vendorFileName = typeof assets.vendor === 'string' ? assets.vendor : assets.vendor[ 0 ];
-	const CDN_PREFIX = process.env.CDN_PREFIX || '';
 
 	return templateCompiler( {
 		content,
@@ -85,10 +84,10 @@ function renderPage( props, localeData, isRtl = false ) {
 		localeData,
 		title,
 		css: process.env.BUILD_STATIC ? '' : css.join( '' ),
-		resetCss: CDN_PREFIX + '/styles/reset.css',
-		bundle: CDN_PREFIX + path.join( bundlePath, bundleFileName ),
-		vendor: CDN_PREFIX + path.join( bundlePath, vendorFileName ),
-		styles: stylesFileName ? CDN_PREFIX + path.resolve( bundlePath, stylesFileName ) : undefined
+		resetCss: '/styles/reset.css',
+		bundle: path.join( bundlePath, bundleFileName ),
+		vendor: path.join( bundlePath, vendorFileName ),
+		styles: stylesFileName ? path.resolve( bundlePath, stylesFileName ) : undefined
 	} );
 }
 

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -6,7 +6,6 @@ var baseConfig = require( './webpack.base.config' ),
 	path = require( 'path' ),
 	fs = require( 'fs' ),
 	webpack = require( 'webpack' ),
-	CDN_PREFIX = process.env.CDN_PREFIX || '',
 	NODE_ENV = process.env.NODE_ENV || 'development';
 
 const vendorModules = [
@@ -52,7 +51,6 @@ var config = merge.smart( baseConfig, {
 
 	output: {
 		path: path.resolve( __dirname, 'public/scripts' ),
-		publicPath: CDN_PREFIX + '/scripts/',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 		filename: 'bundle.[hash].js',
 		sourceMapFilename: 'bundle.[hash].map.js'


### PR DESCRIPTION
This fixes the URLs for chunks on staging, and allows us to switch to the old method of rewriting the static/script URLs on `wpcom` instead of doing it in the build itself. Otherwise, we'd need to generate a staging-specific build.

**Note:** I will revert the change to `circle.yml` before merging. That was just there so that we could generate an artifact for this branch and deploy it to staging.

**Testing**
The testing instructions are on D2972-code.
