### PR TITLE
Domain Setup: Add host name validation to the Set Up Existing Blog page

### DIFF
--- a/app/components/containers/set-up-existing-blog.js
+++ b/app/components/containers/set-up-existing-blog.js
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import { getValues, reduxForm } from 'redux-form';
 
 // Internal dependencies
+import { extractHostName } from 'lib/domains';
 import { getAsyncValidateFunction } from 'lib/form';
 import i18n from 'i18n-calypso';
 import RequireLogin from './require-login';
@@ -10,8 +11,16 @@ import SetUpExistingBlog from 'components/ui/set-up-existing-blog';
 import { redirect } from 'actions/routes';
 
 const validate = values => {
-	if ( ! values.url ) {
+	const { url } = values;
+
+	if ( ! url ) {
 		return { url: i18n.translate( 'Please enter a url.' ) };
+	}
+
+	const hostName = extractHostName( url );
+
+	if ( ! hostName ) {
+		return { url: i18n.translate( "That doesn't look like an address. Copy your blog's address from the address bar at the top of the screen when you visit the blog." ) };
 	}
 
 	return {};

--- a/app/lib/domains/index.js
+++ b/app/lib/domains/index.js
@@ -31,6 +31,38 @@ export function isDomain( value ) {
 }
 
 /**
+ * Retrieves a host name from the specified url.
+ *
+ * @param {string} url - url
+ * @returns {string|null} the corresponding host name, or null if not found
+ */
+export function extractHostName( url ) {
+	// Prepares the url for parsing by removing or converting invalid characters
+	if ( url ) {
+		url = url.replace( /\\/g, '/' );
+		url = url.replace( /[()]/g, '' );
+	}
+
+	const data = parseDomain( url );
+
+	if ( data ) {
+		const { subdomain, domain, tld } = data;
+
+		if ( domain && tld ) {
+			const parts = [ domain, tld ];
+
+			if ( subdomain ) {
+				parts.unshift( subdomain );
+			}
+
+			return parts.join( '.' );
+		}
+	}
+
+	return null;
+}
+
+/**
  * Check if a string is a valid second level domain.
  *
  * @param {string} value - the string to test

--- a/app/lib/domains/tests/index.js
+++ b/app/lib/domains/tests/index.js
@@ -2,6 +2,7 @@ jest.disableAutomock();
 
 // Internal dependencies
 import {
+	extractHostName,
 	isDomain,
 	isDomainSearch,
 	isValidSecondLevelDomain,
@@ -20,7 +21,7 @@ describe( 'lib/domains', () => {
 			expect( isDomain( 'hell-o.com' ) ).toBe( true );
 		} );
 
-		it( 'should not match unvalid domain', () => {
+		it( 'should not match invalid domain', () => {
 			expect( isDomain() ).toBe( false ); // needs a parameter
 			expect( isDomain( null ) ).toBe( false ); // needs a string parameter
 			expect( isDomain( 'helloworld' ) ).toBe( false ); // needs a tld
@@ -45,7 +46,7 @@ describe( 'lib/domains', () => {
 			expect( isValidSecondLevelDomain( 'hello1' ) ).toBe( true );
 		} );
 
-		it( 'should not match unvalid second-level domains', () => {
+		it( 'should not match invalid second-level domains', () => {
 			expect( isValidSecondLevelDomain( 'hello.world' ) ).toBe( false );
 			expect( isValidSecondLevelDomain( 'hello_world' ) ).toBe( false );
 			expect( isValidSecondLevelDomain( '/hello-world' ) ).toBe( false );
@@ -180,6 +181,29 @@ describe( 'lib/domains', () => {
 
 		it( 'should replace an existing TLD with the given one', () => {
 			expect( withTld( 'foo.com', 'blog' ) ).toBe( 'foo.blog' );
+		} );
+	} );
+
+	describe( 'extractHostName', () => {
+		it( 'should return a host name for a valid url', () => {
+			expect( extractHostName( 'hello.com' ) ).toBe( 'hello.com' );
+			expect( extractHostName( 'hello.com/blah_blah' ) ).toBe( 'hello.com' );
+			expect( extractHostName( 'http://hello-world.com' ) ).toBe( 'hello-world.com' );
+			expect( extractHostName( 'https://hello.world.com' ) ).toBe( 'hello.world.com' );
+			expect( extractHostName( 'http://foo.co/blah_blah' ) ).toBe( 'foo.co' );
+			expect( extractHostName( 'http://foo.co/blah_blah.' ) ).toBe( 'foo.co' );
+			expect( extractHostName( 'http://foo.co/blah_blah,' ) ).toBe( 'foo.co' );
+			expect( extractHostName( '(http://foo.co/blah_blah)' ) ).toBe( 'foo.co' );
+			expect( extractHostName( 'http:\\\\foo.co\\blah_blah' ) ).toBe( 'foo.co' );
+			expect( extractHostName( 'foo.co\\\\blah_blah' ) ).toBe( 'foo.co' );
+		} );
+
+		it( 'should return null for an invalid url', () => {
+			expect( extractHostName() ).toBe( null );
+			expect( extractHostName( null ) ).toBe( null );
+			expect( extractHostName( 'helloworld' ) ).toBe( null );
+			expect( extractHostName( '.com' ) ).toBe( null );
+			expect( extractHostName( 'hello.whatever' ) ).toBe( null );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/delphin/issues/713 by validating the site address entered by users on the `Set Up Existing Blog` page:

![screenshot](https://cloud.githubusercontent.com/assets/594356/19199974/e5ffd310-8cc6-11e6-9861-5f1c1fac35b3.png)
#### Testing instructions
1. Run `git checkout update/set-up-existing-blog` and start your server, or open a [live branch](https://delphin.live/?branch=update/set-up-existing-blog)
2. Open the [`Login` page](http://delphin.localhost:1337/log-in) and connect with an account with domains purchased
3. Navigate to the `My Domains` page
4. Click the `Set Up Now` link on any domain
5. Select `A blog I've already created` in the next screen and hit the `Next` button
6. Check that you see an error message for any invalid url upon submitting the form
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
