### PR TITLE
Fix Delphin broken in development

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -36,7 +36,7 @@ if ( window.location.host.indexOf( 'getdotblogstaging' ) > -1 ) {
 	cdnPrefix = config( 'production_cdn_prefix' );
 }
 
-__webpack_public_path__ = cdnPrefix + '/scripts/'; // eslint-disable-line
+__webpack_public_path__ = cdnPrefix + __webpack_public_path__; // eslint-disable-line
 
 const middlewares = [
 	routerMiddleware( browserHistory ),

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -51,6 +51,7 @@ var config = merge.smart( baseConfig, {
 
 	output: {
 		path: path.resolve( __dirname, 'public/scripts' ),
+		publicPath: '/scripts/',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 		filename: 'bundle.[hash].js',
 		sourceMapFilename: 'bundle.[hash].map.js'


### PR DESCRIPTION
This pull request fixes a regression introduced in https://github.com/Automattic/delphin/pull/717 that prevents bundles from loading in development because of a wrong hash, leading to 404 errors:

![screenshot](https://cloud.githubusercontent.com/assets/594356/19221961/aae78eb6-8e4d-11e6-9a48-4100223ca461.png)
#### Testing instructions
1. Run `git checkout fix/bundles-not-found` and start your server, or open a [live branch](https://delphin.live/?branch=fix/bundles-not-found)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that the bundles are loading and that you can log in
4. Sandbox the staging site
5. Apply the patch D2997-code if it hasn't been merged yet
6. Deploy the `fix/bundles-not-found` branch to the staging environment (without committing anything)
7. Open the `Home` page in staging
8. Check that you still get 404s for bundles in your browser but note their file names
9. Check that the `/public/scripts` folder contains these exact file names

The reason we still see errors in step #7 is because assets need to be committed (and probably deployed) in order to be available from our CDN.
#### Additional notes

Please remove the change to the `circle.yml` file **before merging this pull request**.
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
