### PR TITLE
Disable Next button on login page if bundle is not loaded

### DIFF
--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -56,7 +56,7 @@ const ConnectUser = React.createClass( {
 	isSubmitButtonDisabled() {
 		const { invalid, submitting, user: { isRequesting } } = this.props;
 
-		return invalid || submitting || isRequesting;
+		return invalid || submitting || isRequesting || ! process.env.BROWSER;
 	},
 
 	handleSubmit() {


### PR DESCRIPTION
Fix #690 

This PR "disables the Next button on login page if bundle.js is not loaded"
### Testing Instructions
- Go to https://delphin.live/log-in?branch=update/log-in-loading
- Open Chrome devtools and throttle your network speed (Inspect Element > Network to '4G' to slow things down).
- Hard reload the page and notice the button is disabled while the page loads
### Reviews
- [x] Product
- [x] Code

/cc @hafizrahman
