### PR TITLE
Don't fetch the list of states for a country if the selected country value is empty.

### DIFF
--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -61,7 +61,7 @@ class ContactInformation extends React.Component {
 			this.setCountryCode( nextProps );
 		}
 
-		if ( this.props.fields.countryCode.value !== nextProps.fields.countryCode.value ) {
+		if ( this.shouldFetchStates( nextProps ) ) {
 			this.props.fetchStates( nextProps.fields.countryCode.value );
 
 			if ( this.props.fields.countryCode.value ) {
@@ -115,6 +115,10 @@ class ContactInformation extends React.Component {
 	canUpdateCountryFromLocation( props = this.props ) {
 		return ! this.isDataLoading( props ) &&
 			( props.location.hasLoadedFromServer || props.location.hasFailedToLoad );
+	}
+
+	shouldFetchStates( nextProps ) {
+		return this.props.fields.countryCode.value !== nextProps.fields.countryCode.value && nextProps.fields.countryCode.value !== '';
 	}
 
 	isDataLoading( props = this.props ) {


### PR DESCRIPTION
This pull request fixes #706 by not attempting to fetch the list of states when the country code is empty.
#### Testing instructions
1. Run `git checkout add/should-fetch-states` and start your server, or open a [live branch](https://delphin.live/?branch=add/should-fetch-states)
2. Select a domain and navigate to the contact information screen
3. Select US from the country drop down
4. Check that the list of States loads in the state selection field
5. Select "Country" from the country drop down
6. Check that no error message is shown.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
