### PR TITLE
Redirect to WordPress.com to buy a domain mapping

### DIFF
--- a/app/components/ui/set-up-domain/confirm-connect-blog/index.js
+++ b/app/components/ui/set-up-domain/confirm-connect-blog/index.js
@@ -18,7 +18,7 @@ class ConfirmConnectBlog extends Component {
 	handleSubmit( event ) {
 		event.preventDefault();
 
-		const { blogType, domainName } = this.props;
+		const { blogType, domainName, hostName } = this.props;
 
 		let destination;
 
@@ -27,7 +27,7 @@ class ConfirmConnectBlog extends Component {
 		}
 
 		if ( blogType === 'existing' ) {
-			destination = 'https://wordpress.com/';
+			destination = 'https://wordpress.com/checkout/' + hostName + '/domain-mapping:' + domainName;
 		}
 
 		this.props.logInToWpcom( destination );


### PR DESCRIPTION
This pull request redirects users to WordPress.com to purchase a domain mapping if they selected "existing blog" in the flow. This is connected to https://github.com/Automattic/wp-calypso/pull/8678.
#### Testing instructions
1. Run `git checkout add/redirect-to-checkout` and start your server, or open a [live branch](https://delphin.live/?branch=add/redirect-to-checkout)
2. Log in as a user who has domains and go to My Domains
3. Go through the set up flow, selecting an existing WordPress.com blog
4. At the end of the flow you should be redirected to the WordPress.com checkout with this URL: https://wordpress.com/checkout/[wordpress.com-domain]/domain-mapping:[your.blog]. Note that this URL won't work until https://github.com/Automattic/wp-calypso/pull/8678 is merged.
#### Reviews
- [x] Code
- [x] Product

@Automattic/sdev-feed
