### PR TITLE
Add missing peer dependency required for dops-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-core": "^6.7.4",
     "babel-jest": "^14.1.0",
     "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
Currently, `npm install` is falling due to a missing dependency:

```
ERROR in ./~/@automattic/dops-components/client/components/gridicon/index.jsx
Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in "/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/@automattic/dops-components/.babelrc" at
 0, attempted to resolve relative to "/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/@automattic/dops-components"
    at /Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:176:17
    at Array.map (native)
    at Function.normalisePlugins (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:154:20)
    at OptionManager.mergeOptions (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:228:36)
    at OptionManager.init (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:373:12)
    at File.initOptions (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/index.js:221:65)
    at new File (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/index.js:141:24)
    at Pipeline.transform (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-loader/index.js:38:20)
    at Object.module.exports (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-loader/index.js:131:12)
 @ ./app/components/ui/checkout/index.js 108:15-80
 @ ./app/components/containers/checkout.js
 @ ./app/sections/checkout.js
 @ ./app/sections/index.js
 @ ./client/index.js
 @ multi app
```

@drewblaisdell opened a PR to fix this here https://github.com/Automattic/dops-components/pull/66 but I think it's our responsibility to add this dependency to our project and I updated his PR to reflect that.
Long story short, we don't need to wait for that PR to be merged to have this bug fixed in Delphin.
### Testing Instructions
- `git checkout fix/missing-peer-dep`
- `npm start`
- Check that you don't have the error anymore in your terminal
### Reviews
- [x] Product
