### PR TITLE
Fix generation of 404 pages

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -146,8 +146,7 @@ const generateStatic404Files = () => {
 	config( 'languages' )
 		// we filter out `en` because it lives in the top-level static directory, not under `/en/`
 		.filter( language => language.langSlug !== config( 'i18n_default_locale_slug' ) )
-		.map( language => `/${ language.langSlug }/404` )
-		.forEach( generateStaticFile );
+		.forEach( language => generateStaticFile( `/${ language.langSlug }/404`, language.isRtl ) );
 
 	// generate English 404
 	generateStaticFile( '404' );


### PR DESCRIPTION
Fixes #751
This PR fixes the generation of 404 pages by passing the `isRtl` argument for each language.
### Testing Instructions
- `git checkout fix/404`
- `npm run start:static`
- Go to http://delphin.localhost:1337/fr/404 and check that the page is displayed correctly.
### Reviews
- [x] Code
- [x] Product
