### PR TITLE
Update `MyDomains` endpoint path to `/domains`

### DIFF
--- a/app/actions/my-domains.js
+++ b/app/actions/my-domains.js
@@ -17,7 +17,7 @@ export const fetchMyDomains = () => ( {
 	method: 'get',
 	params: {
 		apiNamespace: 'wpcom/v2',
-		path: '/delphin/purchases'
+		path: '/delphin/domains'
 	},
 	loading: MY_DOMAINS_FETCH,
 	success: results => dispatch => dispatch( {


### PR DESCRIPTION
This PR updates the endpoint for the `fetchMyDomains` change to match a change in D3046-code.

**Testing**
- Apply that patch.
- Log into Delphin with an account that has purchased any number of domains.
- Visit `My Domains`.
- Assert that your domains load.
- [x] Code
- [x] Product
