### PR TITLE
Fix Contact Us Exisiting Blog: missing route and bad message value retrieved

### DIFF
--- a/app/components/ui/set-up-domain/contact-us-existing-blog/index.js
+++ b/app/components/ui/set-up-domain/contact-us-existing-blog/index.js
@@ -20,19 +20,20 @@ class ContactUsExistingBlog extends Component {
 		this.handleSubmit = this.props.handleSubmit( this.handleSubmit.bind( this ) );
 	}
 
-	handleSubmit( { message } ) {
+	handleSubmit() {
 		const {
 			addNotice,
 			domainName,
 			hostName,
 			redirect,
+			fields: { message }
 		} = this.props;
 
 		this.props.contactSupport( {
 			blogType: 'existing',
 			domainName,
 			hostName,
-			message
+			message: message.value
 		} ).then( () => {
 			redirect( 'myDomains' );
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -165,6 +165,12 @@ let publicRoutes = [
 				getComponent: getComponent( 'setUpDomain', 'confirmConnectBlog' )
 			},
 			{
+				path: 'set-up-domain/:domainName/existing-blog/contact-us/:hostName',
+				slug: 'contactUsExistingBlog',
+				static: false,
+				getComponent: getComponent( 'setUpDomain', 'contactUsExistingBlog' )
+			},
+			{
 				path: 'set-up-domain/:domainName/hosts',
 				slug: 'hosts',
 				static: false,


### PR DESCRIPTION
This PR fixes the empty message being sent to Kayako when a user enters a message on the contact us form in the case his blog exists.
### Testing Instructions
- `git checkout fix/contact-us-existing`
- `npm start`
- Navigate to `/my-domains` after being logged in
- Select a domain to set up
- Select `Use it for a blog I already started`
- Enter `youtube.com`, Next
- Enter a message and click on `Submit Request`
- Check that an email is sent to kyako and that it contains the actual message
### Reviews
- [x] Code
- [x] Product
