### PR TITLE
Fix sumitting subscribe form

### DIFF
--- a/app/components/containers/learn-more.js
+++ b/app/components/containers/learn-more.js
@@ -1,4 +1,6 @@
 // External dependencies
+import isEmpty from 'lodash/isEmpty';
+import omitBy from 'lodash/omitBy';
 import { reduxForm, reset } from 'redux-form';
 
 // Internal dependencies
@@ -8,10 +10,10 @@ import { validateDomain } from 'lib/domains';
 import { validateEmail } from 'lib/form';
 import LearnMore from 'components/ui/learn-more';
 
-const validate = ( values ) => ( {
+const validate = ( values ) => omitBy( {
 	domain: validateDomain( values.domain ),
 	email: validateEmail( values.email )
-} );
+}, isEmpty );
 
 export default reduxForm(
 	{


### PR DESCRIPTION
Fix subscribe form on `/learn-more`. Currently, entering a valid domain name and email doesn't do anything on the form. It seems this https://github.com/Automattic/delphin/pull/654 broke it.
By not omitting `null` fields here we make `getAsyncValidateFunction` reject the promise (because `isEmpty( { domain: null, email: null } )` is `false`).
### Testing Instructions
- Open https://delphin.live/learn-more?branch=fix/learn-more-signup or checkout this branch locally and navigate to `/learn-more`.
- Submit a valid domain name and email and click on "Get Updates"
- Assert that you receive an email confirmation and that after confirming you are added to the list on mailchimp.
- Try empty/invalid values for domain name and/or email and check that form validation works as expected
### Reviews
- [x] Product
- Code should be alright since it basically revert part of #654
