### PR TITLE
My Domains: Fix support for arbitrary parameters in /domains endpoint

### DIFF
--- a/client/wpcom-middleware/index.js
+++ b/client/wpcom-middleware/index.js
@@ -52,16 +52,18 @@ function addLocaleQueryParam( locale, query, apiNamespace ) {
  * @return {object} New query parameter object with additional properties
  */
 function addLocalStorageCheckoutPropertiesToQuery( path, query ) {
-	const checkoutPaths = [ '/me/paygate-configuration', '/delphin/purchases', '/delphin/transactions' ];
+	const checkoutPaths = [ '/me/paygate-configuration', '/delphin/domains', '/delphin/transactions' ];
+
 	const checkoutPropertiesString = localStorage.getItem( 'delphin:checkout' );
+
 	if ( checkoutPaths.indexOf( path ) === -1 || ! checkoutPropertiesString ) {
 		return query;
 	}
 
-	const checkoutProperties = checkoutPropertiesString.split( ':' );
+	const [ key, value ] = checkoutPropertiesString.split( ':' );
 
 	return Object.assign( {}, query, {
-		[ checkoutProperties[ 0 ] ]: checkoutProperties[ 1 ]
+		[ key ]: value
 	} );
 }
 


### PR DESCRIPTION
This pull request fixes a regression introduced in https://github.com/Automattic/delphin/pull/757 when the `/purchases` endpoint was renamed.

![screenshot](https://cloud.githubusercontent.com/assets/594356/19830050/582e6a16-9df0-11e6-9889-6f2677b452d7.png)
#### Testing instructions
1. Run `git checkout fix/my-domains-arbitrary-parameters` and start your server, or open a [live branch](https://delphin.live/?branch=fix/my-domains-arbitrary-parameters)
2. Open the [`Login` page](http://delphin.localhost:1337/log-in) and connect with an account with domains purchased
3. Navigate to the `My Domains` page
4. Check that you see domains purchased with the store sandbox
#### Reviews
- [x] Code
- [x] Product
- [x] Tests

@Automattic/sdev-feed
