### PR TITLE
Fix IE11 footer bug

### DIFF
--- a/app/components/ui/layout/styles.scss
+++ b/app/components/ui/layout/styles.scss
@@ -21,7 +21,7 @@ h6 {
 }
 
 .content {
-	flex: 1;
+	flex-grow: 1;
 }
 
 a {


### PR DESCRIPTION
This fixes #792 because why would we want the footer to be in the header?

**Before**
![virtualbox_ie11 - win7_09_11_2016_16_20_30](https://cloud.githubusercontent.com/assets/448298/20155162/9e9551b2-a698-11e6-9ddb-b16b1fcfde2c.png)

**After**
![virtualbox_ie11 - win7_09_11_2016_16_16_13](https://cloud.githubusercontent.com/assets/448298/20155170/a2eeeafc-a698-11e6-8a12-f3be5c4207e9.png)

#### Testing

* Look at any page in IE11
* Is the footer in the footer?
* Make sure I didn't break anything in other browsers

#### Review

- [x] Code
- [x] Product