### PR TITLE
Search: Disable autocomplete in search input

### DIFF
--- a/app/components/ui/search-input/index.js
+++ b/app/components/ui/search-input/index.js
@@ -44,6 +44,8 @@ class SearchInput extends React.Component {
 			<form className={ styles.searchWrapper } onSubmit={ this.handleSubmit }>
 				<KeywordsContainer />
 				<input
+					autoCapitalize="off"
+					autoComplete="off"
 					autoFocus
 					ref="searchInput"
 					type="text"


### PR DESCRIPTION
We allow `automocomplete` for input field when searching for domains. It might be one of the reasons why we see so many errors like #692. It is browser internal issue, but as we have `autocomplete` off on the homepage, we can also align behavior of search input on Search page.

#### Testing instructions
  
1. Run `git checkout update/turn-autocomplete-off-search-header` and start your server, or open a [live branch](https://delphin.live/?branch=update/turn-autocomplete-off-search-header)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Type some keyword and click `Get started`.
4. Make sure that input field in the header has autocomplete and autocapitalize disabled.
    
#### Reviews
  
- [x] Code
- [x] Product
   