### PR TITLE
Display domain not available error

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -81,7 +81,7 @@ const Checkout = React.createClass( {
 		if ( error && [ 'duplicate_purchase', 'domain_availability_error', 'domain_availability_check_error' ].includes( error.code ) ) {
 			errorMessage = error.message;
 
-			if ( error.code === 'domain_availability_error' ) {
+			if ( [ 'duplicate_purchase', 'domain_availability_error' ].includes( error.code ) ) {
 				showTryDifferentDomain = true;
 			}
 		}


### PR DESCRIPTION
This pull request displays domain not avail. error, it also prevent user from retrying, because there is no point on retrying not available domain.
  
![screen shot 2016-11-10 at 17 47 44](https://cloud.githubusercontent.com/assets/326402/20183425/f16f8576-a76d-11e6-9db1-41c67808dbce.png)


This should be tested with D3320

#### Testing instructions
  
1. Apply the server-side patch D3320-code and sandbox the API
2. Run `git checkout add/domain-not-availible-error` and start your server, or open a [live branch](https://delphin.live/?branch=add/domain-not-availible-error)
3. Open the [`Confirm Domain` page](http://delphin.localhost:1337/fr/confirm-domain?domain=travel.blog) for `travel.blog`
4. Proceed to the `Checkout Review` page and click the `Submit application & pay now` button
5. Check that you are presented with the following error message:
> This domain is not available.
>
> You can try a different domain.
6. Click the `try a different domain` link
7. Search a domain that you have already purchased with this account now
8. Proceed to the `Checkout Review` page and click the submit button again
9. Check that you are presented with the following error message:
> You have already purchased an application for this domain.
> 
> You can try a different domain.
10. Click the `try a different domain` link again
11. Search a domain that is available this time
12. Proceed to the `Checkout` page and enter a wrong expiration date (in the past) for the credit card
13. Proceed to the `Checkout Review` page and click the submit button again
14. Check that you are presented with the following error message:
> We weren't able to process your payment.
>
> Don't worry! You can try again.

#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed
