### PR TITLE
Fixes out of place logo in IE on search results page

### DIFF
--- a/app/components/ui/header/styles.scss
+++ b/app/components/ui/header/styles.scss
@@ -65,5 +65,6 @@
 		padding: 30px 30px 30px 10px;
 		position: absolute;
 		right: 0;
+		top: 0;
 	}
 }


### PR DESCRIPTION
Fixes #804 

**Before:**

![image](https://cloud.githubusercontent.com/assets/12596797/20188732/f713f456-a747-11e6-85e6-03e8230c54de.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/12596797/20188743/02197236-a748-11e6-9149-ed6e421896dc.png)

**Testing**
* Look at search results page in IE11
* Is the logo in the right place?
* Make sure I didn't break anything in other browsers

- [x] Code
- [x] Product