### PR TITLE
Update setup complete page

### DIFF
--- a/app/components/ui/form/field-area/styles.scss
+++ b/app/components/ui/form/field-area/styles.scss
@@ -73,4 +73,10 @@
 			margin-top: 20px;
 		}
 	}
+
+	h3 {
+		color: $blue-dark;
+		font-size: 2rem;
+		font-weight: 600;
+	}
 }

--- a/app/components/ui/set-up-domain/confirm-connect-blog/index.js
+++ b/app/components/ui/set-up-domain/confirm-connect-blog/index.js
@@ -72,15 +72,15 @@ class ConfirmConnectBlog extends Component {
 				<Form onSubmit={ this.handleSubmit }>
 					{ blogType === 'existing' && (
 						<Form.FieldArea>
+							<h3>
+								{ i18n.translate( 'Your domain is all set!' ) }
+							</h3>
+
 							<p>
-								{ i18n.translate( "You're all set! We just made some changes for you so %(domainName)s will point to %(hostName)s.", {
+								{ i18n.translate( 'We just made some changes for you so %(domainName)s will point to %(hostName)s.', {
 									args: { hostName, domainName },
 									components: { strong: <strong /> }
 								} ) }
-							</p>
-
-							<p>
-								{ preventWidows( i18n.translate( "Just a reminder you won't see the changes right away. It can take up to 72 hours for settings to be updated across the web." ), 2 ) }
 							</p>
 
 							<Button className={ styles.button }>
@@ -94,35 +94,35 @@ class ConfirmConnectBlog extends Component {
 
 					{ blogType === 'new' && (
 						<Form.FieldArea>
-							<p>
-								{ preventWidows( i18n.translate( "You're all set! Just sign up at %(serviceName)s and create your new blog.", {
+							<h3>
+								{ i18n.translate( 'Your domain is ready for %(serviceName)s!', {
 									args: { serviceName },
 									comment: 'serviceName is the name of a hosting service, e.g. WordPress.com.'
-								} ), 2 ) }
-							</p>
+								} ) }
+							</h3>
 
 							<p>
-								{ preventWidows( i18n.translate( 'To get started, sign up at %(serviceName)s and create a new blog. Your domain will connect automatically.', {
-									args: { serviceName },
+								{ preventWidows( i18n.translate( 'Continue to %(serviceName)s to start building your new blog. After you create your blog with %(serviceName)s it will be available at %(domainName)s', {
+									args: { serviceName, domainName },
 									comment: 'serviceName is the name of a hosting service, e.g. WordPress.com.'
 								} ), 2 ) }
 							</p>
 
 							<Button className={ styles.button }>
-								{ i18n.translate( 'Sign up at %(serviceName)s', {
+								{ i18n.translate( 'Create my %(serviceName)s blog', {
 									args: { serviceName },
 									comment: 'serviceName is the name of a hosting service, e.g. WordPress.com.'
 								} ) }
 							</Button>
 						</Form.FieldArea>
 					) }
-
-					<Form.SubmitArea>
-						<Link to={ getPath( 'myDomains' ) }>
-							{ i18n.translate( 'Back to My Domains' ) }
-						</Link>
-					</Form.SubmitArea>
 				</Form>
+
+				<SunriseStep.Footer>
+					<Link to={ getPath( 'myDomains' ) }>
+						{ i18n.translate( 'Back to My Domains' ) }
+					</Link>
+				</SunriseStep.Footer>
 			</SunriseStep>
 		);
 	}


### PR DESCRIPTION
This updates the copy and some slight design modifications to the final screen in the domain setup flow as shown in #761.

The screen has some design inconsistencies with the proposed design in that issue because the progress bar at the top still needs some refinement. It's also missing the blue top border that will be merged with #886.

#### Before

Existing blog
![image](https://cloud.githubusercontent.com/assets/448298/20195852/24fb82d0-a766-11e6-8c51-3aa9bcbf1e8f.png)

New blog
![image](https://cloud.githubusercontent.com/assets/448298/20195911/544711da-a766-11e6-947b-e27d231d429a.png)

#### After

Existing blog
![image](https://cloud.githubusercontent.com/assets/448298/20195757/d4af5b1c-a765-11e6-8b64-2130a838135a.png)

New blog
![image](https://cloud.githubusercontent.com/assets/448298/20195776/e42d64ee-a765-11e6-8895-9f2a48674ff4.png)


#### Testing

* Start at `/my-domains` and select a domain to set up
* Go through the flow to set up a new blog
* When you reach the success page, confirm you see the copy and design changes
* Try out the existing blog flow

#### Review

- [x] Code
- [x] Product