### PR TITLE
Fix: Users seeing failure on transaction success

### DIFF
--- a/client/ad-tracking-middleware/index.js
+++ b/client/ad-tracking-middleware/index.js
@@ -12,7 +12,8 @@ export const adTrackingMiddleware = () => next => action => {
 
 	switch ( type ) {
 		case TRANSACTION_CREATE_COMPLETE:
-			if ( isEnabled( 'ad_tracking' ) ) {
+			// users might block google_trackConversion, we must not fail because of it
+			if ( isEnabled( 'ad_tracking' ) && typeof window.google_trackConversion === 'function' ) {
 				window.google_trackConversion( {
 					google_conversion_id: config( 'google_conversion_id' ),
 					google_conversion_format: 3,


### PR DESCRIPTION
Some users have a plugin called "uBlock origin" (or similar) that is blocking
user tracking facilities, such as google conversion tracking:

<img width="972" alt="screen shot 2016-11-12 at 13 51 25" src="https://cloud.githubusercontent.com/assets/326402/20237602/c4501164-a8df-11e6-8f94-66a34f89f5cb.png">
<img width="1257" alt="screen shot 2016-11-12 at 13 49 00" src="https://cloud.githubusercontent.com/assets/326402/20237603/c6ebcd14-a8df-11e6-8f7a-da6298d9d19e.png">

We shouldn't fail because of it.
  
#### Testing instructions
  
1. Run `git checkout fix/trancation-failure-on-sucess` and start your server
2. Ensure `ad_tracking` is turned on at config
3. Install the plugin [uBlock origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)
4. Complete the flow and assert you bought a domain successfully
    
#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed
