### PR TITLE
Framework: Fix yarn install on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,10 @@ machine:
 
 dependencies:
   pre:
-    - curl -o- -L https://yarnpkg.com/install.sh | bash
+    - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+    - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    - sudo apt-get update -qq
+    - sudo apt-get install -y -qq yarn
   cache_directories:
     - ~/.yarn-cache
   override:


### PR DESCRIPTION
Related CircleCI documentation: https://yarnpkg.com/en/docs/install-ci#circle-tab.