### PR TITLE
Fix the padding of search header on mobile

### DIFF
--- a/app/components/ui/header/styles.scss
+++ b/app/components/ui/header/styles.scss
@@ -25,7 +25,7 @@
 	z-index: 1;
 
 	@include breakpoint( '<660px' ) {
-		flex-direction: column-reverse;
+		flex-wrap: wrap;
 		height: auto;
 	}
 
@@ -44,6 +44,7 @@
 	}
 
 	@include breakpoint( '>480px' ) {
+		order: 1;
 		padding: 30px;
 
 		img {

--- a/app/components/ui/search-input/styles.scss
+++ b/app/components/ui/search-input/styles.scss
@@ -33,6 +33,7 @@
 
 	@include breakpoint( '<660px' ) {
 		flex-direction: column;
+		order: 2;
 	}
 }
 


### PR DESCRIPTION
Fixes #788 

**Before:**
![image](https://cloud.githubusercontent.com/assets/12596797/20323256/ee9b99b8-ab49-11e6-9a20-0e0de493bace.png)


**After:**
![image](https://cloud.githubusercontent.com/assets/12596797/20323238/ddd1d9bc-ab49-11e6-8d2b-73582eb6a5d8.png)

**Testing**
1. Search for a domain on a mobile device (both iOS and Android - also occurs in Safari on desktop when sized down).
2. On the search results page ensure that search bar is container within the header.
3. Make sure I didn't break anything else.

- [x] Code
- [x] Product