### PR TITLE
Pass `host_name` parameter to the API when updating a domain's service

### DIFF
--- a/app/actions/my-domains.js
+++ b/app/actions/my-domains.js
@@ -41,7 +41,7 @@ export const fetchMyDomains = () => ( {
 	}
 } );
 
-export const updateDomain = ( domain, serviceSlug ) => ( {
+export const updateDomain = ( domain, serviceSlug, hostName = '' ) => ( {
 	type: WPCOM_REQUEST,
 	method: 'post',
 	params: {
@@ -49,7 +49,8 @@ export const updateDomain = ( domain, serviceSlug ) => ( {
 		path: '/delphin/domain/' + domain
 	},
 	payload: snakeifyKeys( {
-		serviceSlug
+		serviceSlug,
+		hostName,
 	} ),
 	loading: DOMAIN_UPDATE_POST,
 	success: results => ( {

--- a/app/components/ui/set-up-domain/connect-existing-blog/index.js
+++ b/app/components/ui/set-up-domain/connect-existing-blog/index.js
@@ -20,7 +20,7 @@ class ConnectExistingBlog extends Component {
 
 		const { domainName, hostName, redirect, service, updateDomain } = this.props;
 
-		updateDomain( domainName, service )
+		updateDomain( domainName, service, hostName )
 			.then( () => {
 				redirect( 'confirmConnectExistingBlog', { pathParams: { domainName, hostName } } );
 			} )


### PR DESCRIPTION
Requires D3383-code.

We need to pass this property to the server in order to save the `host_name` that the user entered.

**Testing**
Testing instructions are on D3383-code.

- [x] Code
- [x] Product