### PR TITLE
Update card expiration year to +20 years.

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -218,7 +218,7 @@ const Checkout = React.createClass( {
 									>
 										<option value="">{ i18n.translate( 'Year' ) }</option>
 										{
-											range( ( new Date() ).getFullYear(), ( new Date() ).getFullYear() + 6 ).map(
+											range( ( new Date() ).getFullYear(), ( new Date() ).getFullYear() + 21 ).map(
 												( year ) => <option value={ padStart( year - 2000, 2, '0' ) } key={ year } >{ year }</option>
 											)
 										}


### PR DESCRIPTION
To fix #925.

I looked this up and apparently [there is no set maximum year for a card's expiration year](http://stackoverflow.com/questions/2500588/maximum-year-in-expiry-date-of-credit-card).

I checked and can confirm that Amazon uses 20 years in the future. If it's good enough for them, it's good enough for Delphin.

#### Testing instructions

1. Run `git checkout update/card-expiration-year`
2. Go through the new domain purchase flow until you're at the `/checkout` page where you're required to enter credit card info
3. Expand the "Year" dropdown and make sure the maximum year is now 2036.

#### Reviews

- [x] Code
- [x] Product
 