### PR TITLE
Add more specific errors

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -93,6 +93,10 @@ const Checkout = React.createClass( {
 			}
 		}
 
+		if ( error && error.code === 'registrar_error' ) {
+			errorMessage = i18n.translate( 'There was a problem trying to register your domain' );
+		}
+
 		return (
 			<div className={ styles.checkoutError }>
 				<div className={ styles.icon }></div>


### PR DESCRIPTION
When we have a `registrar_error` we display a payment error to the user which is confusing. We should show a different type of error here to make it clear that it's not payments related.
  
#### Testing instructions
  
1. Run `git checkout add/error-message` and start your server, or open a [live branch](https://delphin.live/?branch=add/error-message)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Try to purchase anothertestingtest.live
4. Check that you see this error: `There was a problem trying to register your domain`.

On master you will see an error related to payments.
  
#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed