### PR TITLE
Remove extraneous 'now' in domain set up step

### DIFF
--- a/app/components/ui/set-up-domain/select-blog-type/index.js
+++ b/app/components/ui/set-up-domain/select-blog-type/index.js
@@ -83,7 +83,7 @@ class SelectBlogType extends Component {
 								value="new"
 								checked={ newOrExisting.value === 'new' }
 							/>
-							{ i18n.translate( 'A new blog now I\'ll start now.' ) }
+							{ i18n.translate( 'A new blog I\'ll start now.' ) }
 						</label>
 					</Form.FieldArea>
 


### PR DESCRIPTION
Fix for #960.

How to test:

#### Testing instructions

1. Run `git checkout fix/typo-select-blog`
2. Go to My Domains and find an unused domain, click "Set up"
3. Make sure that the second option on the next screen says `A new blog I'll start now.` This should be on the `/set-up-domain/[domain_name]` URL.

#### Reviews

- [x] Code
- [x] Product
 
