### PR TITLE
Fix: Empty contact information unable to proceed

### DIFF
--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -87,6 +87,12 @@ class ContactInformation extends React.Component {
 				}
 			}
 
+			// If we didn't got an email from the contactInformation above,
+			// lets set it to logged in user's email
+			if ( fieldName === 'email' && ! value ) {
+				value = props.user.data.email;
+			}
+
 			return Object.assign( result, { [ fieldName ]: value } );
 		}, {} );
 
@@ -134,12 +140,6 @@ class ContactInformation extends React.Component {
 		const { inputVisibility: { address2InputIsVisible }, fields: { address2 } } = this.props;
 
 		return address2InputIsVisible || address2.initialValue;
-	}
-
-	emailInputIsVisible() {
-		const { fields: { email } } = this.props;
-
-		return email.initialValue && email.initialValue.includes( '+' );
 	}
 
 	organizationInputIsVisible() {
@@ -261,20 +261,18 @@ class ContactInformation extends React.Component {
 									</fieldset>
 								) }
 
-								{ this.emailInputIsVisible() && (
-									<fieldset>
-										<label>{ i18n.translate( 'Email' ) }</label>
-										<Input
-											disabled={ this.isDataLoading() }
-											field={ fields.email }
-											placeholder={ i18n.translate( 'Email' ) }
-											untouch={ untouch }
-											type="email"
-											dir="ltr"
-										/>
-										<ValidationError field={ fields.email } />
-									</fieldset>
-								) }
+								<fieldset>
+									<label>{ i18n.translate( 'Email' ) }</label>
+									<Input
+										disabled={ this.isDataLoading() }
+										field={ fields.email }
+										placeholder={ i18n.translate( 'Email' ) }
+										untouch={ untouch }
+										type="email"
+										dir="ltr"
+									/>
+									<ValidationError field={ fields.email } />
+								</fieldset>
 
 								<fieldset>
 									<label>{ i18n.translate( 'Address' ) }</label>


### PR DESCRIPTION
This pull request fixes a problem when a user that had failed/empty contact information
endpoint response couldn't proceed because it had no email set by **always showing
the email field**.

Related to #966 and  ##950
  
#### Testing instructions
  
1. Run `git checkout fix/empty-contact-information` and start your server, or open a [live branch](https://delphin.live/?branch=fix/empty-contact-information)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Complete the flow, see you can get to the checkout page ok.
  
#### Additional notes
  
[Remove the commit that fails contact information fetch request](https://github.com/Automattic/delphin/commit/363b44693846c3edad2587f83ab64593e60872ac)
  
#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed
