### PR TITLE
Update copy on success page

### DIFF
--- a/app/components/ui/success/index.js
+++ b/app/components/ui/success/index.js
@@ -46,8 +46,12 @@ class Success extends React.Component {
 
 					<div className={ styles.text }>
 						<p>
+							{ i18n.translate( 'Your domain should start working right away, but it may not be reliable for the first few hours.' ) }
+						</p>
+
+						<p>
 							{ i18n.translate(
-								'Your new domain is almost ready. Connect your existing blog or start a new one now.'
+								'Connect your existing blog or start a new one now.'
 							) }
 						</p>
 


### PR DESCRIPTION
Fixes #961. I removed one sentence that sounded redundant, we'll need to send a new translation.

Before | After
------------ | -------------
![image](https://cloud.githubusercontent.com/assets/448298/20529905/cd58bd48-b09f-11e6-9733-b7eff693bb93.png) | ![image](https://cloud.githubusercontent.com/assets/448298/20529858/a6acf074-b09f-11e6-806c-0a82f6311833.png)


#### Testing

* Purchase a domain to reach the success page
* Confirm the copy has been updated and there are no typos

#### Review

- [x] Code
- [x] Product
- [x] Design