### PR TITLE
Remove signup specific info from login

### DIFF
--- a/app/components/ui/connect-user/header/index.js
+++ b/app/components/ui/connect-user/header/index.js
@@ -15,6 +15,11 @@ const Header = ( { intention, domainName } ) => {
 		text = i18n.translate( 'Enter your email address to register %(domainName)s.', {
 			args: { domainName }
 		} );
+	} else if ( intention === 'login' ) {
+		heading = i18n.translate( 'Log in' );
+		text = i18n.translate( 'We\'ll send you a link to log in.', {
+			args: { domainName }
+		} );
 	} else if ( intention === 'verifyUser' ) {
 		heading = i18n.translate( 'Check your email' );
 

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -64,14 +64,31 @@ const ConnectUser = React.createClass( {
 	},
 
 	renderTermsOfService() {
-		return <section className={ styles.terms }>
-			{ i18n.translate( 'By clicking Next, you understand that you will get a WordPress.com account as a part of signing up at get.blog, and agree to these ' +
-			'{{link}}Terms of Service{{/link}}.',
-				{
-					components: { link: <a href="https://wordpress.com/tos/" target="_blank" /> }
-				}
-			) }
-		</section>;
+		const { intention } = this.props;
+		if ( intention === 'signup' ) {
+			return <section className={ styles.terms }>
+				{ i18n.translate( 'By clicking Next, you understand that you will get a WordPress.com account as a part of signing up at get.blog, and agree to these ' +
+				'{{link}}Terms of Service{{/link}}.',
+					{
+						components: { link: <a href="https://wordpress.com/tos/" target="_blank" /> }
+					}
+				) }
+			</section>;
+		}
+	},
+
+	renderPoweredBy() {
+		const { intention } = this.props;
+		if ( intention === 'signup' ) {
+			return <div className={ styles.poweredBy }>
+				<h3 className={ styles.headline }>
+					{ i18n.translate( 'Proudly powered by WordPress.com' ) }
+				</h3>
+				<p>
+					{ i18n.translate( 'Your get.blog domain can easily be connected to a WordPress.com blog.' ) }
+				</p>
+			</div>;
+		}
 	},
 
 	render() {
@@ -99,14 +116,7 @@ const ConnectUser = React.createClass( {
 								{ i18n.translate( 'Next' ) }
 							</Button>
 						</Form.SubmitArea>
-						<div className={ styles.poweredBy }>
-							<h3 className={ styles.headline }>
-								{ i18n.translate( 'Proudly powered by WordPress.com' ) }
-							</h3>
-							<p>
-								{ i18n.translate( 'Your get.blog domain can easily be connected to a WordPress.com blog.' ) }
-							</p>
-						</div>
+						{ this.renderPoweredBy() }
 					</Form>
 
 				</div>


### PR DESCRIPTION
Fixes #968 

**Before** | **After**
--------- | ---------
![image](https://cloud.githubusercontent.com/assets/12596797/20531668/7217cd06-b0a5-11e6-950f-b7a297423dbc.png) | ![image](https://cloud.githubusercontent.com/assets/12596797/20531567/20f06c58-b0a5-11e6-8859-7c986250b5b4.png)

**Testing**
1. Verify that the login page no longer has tos and the "powered by" message.
2. Verify that the signup page is unchanged.


- [x] Code
- [x] Product