### PR TITLE
Add domain assistant illustration to setup screens

### DIFF
--- a/app/components/ui/set-up-domain/connect-new-blog/styles.scss
+++ b/app/components/ui/set-up-domain/connect-new-blog/styles.scss
@@ -1,6 +1,13 @@
 @import 'app/styles/assets';
 @import 'app/components/ui/set-up-domain/styles';
 
+.header-text {
+	background: url( #{$image-assets-url}ui-illustrations/domain-concierge.svg ) no-repeat center top;
+	background-size: 100px;
+	margin-top: 0;
+	padding-top: 115px;
+}
+
 .paragraph {
 	font-size: 1.6rem;
 	line-height: 1.3;

--- a/app/components/ui/set-up-domain/contact-concierge/styles.scss
+++ b/app/components/ui/set-up-domain/contact-concierge/styles.scss
@@ -2,7 +2,7 @@
 @import 'app/components/ui/set-up-domain/styles';
 
 .header-text {
-	background: url( #{$image-assets-url}domain-assistant-mock-100px-2x.png) no-repeat center top;
+	background: url( #{$image-assets-url}ui-illustrations/domain-concierge.svg ) no-repeat center top;
 	background-size: 100px;
 	margin-top: 0;
 	padding-top: 115px;

--- a/app/components/ui/set-up-domain/contact-us-existing-blog/styles.scss
+++ b/app/components/ui/set-up-domain/contact-us-existing-blog/styles.scss
@@ -1,6 +1,13 @@
 @import 'app/styles/assets';
 @import 'app/components/ui/set-up-domain/styles';
 
+.header-text {
+	background: url( #{$image-assets-url}ui-illustrations/domain-concierge.svg ) no-repeat center top;
+	background-size: 100px;
+	margin-top: 0;
+	padding-top: 115px;
+}
+
 .paragraph {
 	font-size: 1.6rem;
 	line-height: 1.3;


### PR DESCRIPTION
Adding the domain assistant illustration to the contact form screens.

Before | After
------------ | -------------
![image](https://cloud.githubusercontent.com/assets/448298/20577433/4083aada-b190-11e6-8ec9-86a34e5b93ec.png) | ![image](https://cloud.githubusercontent.com/assets/448298/20577413/2a90300e-b190-11e6-80ee-f83ca95f56c7.png)

#### Testing

* Go through the domain setup flow for existing blog
* Type in `a.com` or some other domain that isn't WordPress.com
* Confirm the illustration is shown
* Go through the domain setup flow for a new blog
* Click the link in the form footer on the host selection screen
* Confirm the illustration is shown
* Go back to My Domains and click the link to contact the domain assistant on the associated card
* Confirm the illustration is shown here too

#### Review

- [x] Code
- [x] Product