### PR TITLE
Improve SERP with better title and description meta tags

### DIFF
--- a/app/components/ui/sunrise-home/index.js
+++ b/app/components/ui/sunrise-home/index.js
@@ -42,7 +42,7 @@ const SunriseHome = React.createClass( {
 					method="get"
 					action={ getPath( 'search' ) }
 				>
-					<DocumentTitle />
+					<DocumentTitle title={ i18n.translate( 'Find a new .blog domain for your blog.' ) } />
 
 					<h2 className={ styles.heading }>
 						{ preventWidows( pageHeading, 2 ) }

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -2,6 +2,7 @@ doctype html
 html(dir=isRtl ? 'rtl' : 'ltr' )
 	head
 		title=title
+		meta(name="description" content=ogDescription)
 		meta(name="viewport" content="width=device-width, initial-scale=1.0")
 		meta(name="twitter:card" content="summary")
 		meta(name="twitter:creator" content="@wordpressdotcom")


### PR DESCRIPTION
Fixes #993 

I added a more descriptive `<title>` tag on the homepage and used the same text for `<description>` that is used in the `og:description` for social sharing.

#### Testing

* Visit the homepage and confirm the title in the browser tab says `Find a new .blog domain for your blog. | get.blog`
* View page source and confirm there's a `<meta name="description"` tag in the HTML head
* Make sure page titles on other pages aren't affected.

#### Review

- [x] Code
- [x] Product