### PR TITLE
Add link for users to update their nameservers in `DomainManagedByConierge`

### DIFF
--- a/app/components/ui/my-domains/domain-card/domain-managed-by-concierge.js
+++ b/app/components/ui/my-domains/domain-card/domain-managed-by-concierge.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
+import CustomNameServersLink from 'components/ui/set-up-domain/custom-name-servers-link';
 import { getPath } from 'routes';
 import styles from './styles.scss';
 
@@ -20,6 +21,9 @@ const DomainManagedByConcierge = ( { domainName, hostName } ) => {
 				<p className={ styles.smallText }>
 					<Link to={ getPath( 'contactConcierge', { domainName, hostName } ) }>{ i18n.translate( 'Contact your domain concierge.' ) }</Link>
 				</p>
+			</div>
+			<div className={ styles.customNameserversContainer }>
+				<CustomNameServersLink domainName={ domainName } />
 			</div>
 		</div>
 	);

--- a/app/components/ui/my-domains/domain-card/styles.scss
+++ b/app/components/ui/my-domains/domain-card/styles.scss
@@ -241,3 +241,11 @@
 		margin-left: 0;
 	}
 }
+
+.custom-nameservers-container {
+	border-top: solid 1px $gray-light;
+	font-size: 1.4rem;
+	margin: 0 0 10px;
+	padding: 10px 0 0;
+	text-align: center;
+}


### PR DESCRIPTION
Addresses part of #982. Note that we may still need to find a way to notify HEs that a user's domain has left the `concierge` state.

<img width="396" alt="screen shot 2016-11-24 at 12 39 53 pm" src="https://cloud.githubusercontent.com/assets/1130674/20586005/4afcee6e-b243-11e6-8c3a-acbe86693798.png">

This PR adds a link to `DomainManagedByConcierge` to allow users to update nameservers manually, even if they are in the concierge state.

**Testing**
- Visit `My Domains`.
- Find a domain that is in the `concierge` state.
- Assert that you see the `Configure manually` link above.
- Click the link.
- Update your nameservers.
- Assert that you are redirected to `My Domains` and that the domain is now in the `custom` state.

- [x] Code
- [x] Product