### PR TITLE
Checkout: Update string to match existing translation

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -284,8 +284,8 @@ const Checkout = React.createClass( {
 								<span className={ styles.itemDescription }>
 									{ this.props.domain.domainName }
 								</span>
-								<span>{ i18n.translate( '%(domainCost)s per year', {
-									args: { domainCost },
+								<span>{ i18n.translate( '%(cost)s per year', {
+									args: { cost: domainCost },
 								} ) }</span>
 							</div>
 							<div className={ styles.orderItem }>


### PR DESCRIPTION
This pull request updates a string on the `Checkout` page to reuse an existing translation. In fine, it only changes an argument name.

![screenshot](https://cloud.githubusercontent.com/assets/594356/20625904/5c9ef12a-b316-11e6-9aa9-2f6e57029b98.png)


#### Testing instructions

1. Run `git checkout fix/translations` and start your server, or open a [live branch](https://delphin.live/?branch=fix/translations)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Proceed to the `Checkout` page and check that the renewal price is correctly displayed

#### Reviews

- [x] Code
- [ ] Product
 
@Automattic/sdev-feed
