### PR TITLE
Turn the links to regular link color.

### DIFF
--- a/app/components/ui/contact-information/styles.scss
+++ b/app/components/ui/contact-information/styles.scss
@@ -101,7 +101,7 @@
 
 .show-organization-link,
 .show-address-two-link {
-	color: $gray-dark;
+	color: $blue;
 	display: inline-block;
 	font-size: 1.4rem;
 	margin-top: 5px;


### PR DESCRIPTION
To fix #795

#### Testing instructions

1. Run `git checkout fix/contact-info-links`
2. Try to register a new domain name, until you're at the contact info form (`/contact-information')
3. Make sure both links for adding company name and second address line are blue, instead of dark gray 
4. Make sure the hover color for them is a lighter shade of blue


#### Reviews

- [x] Code
- [x] Product
 
