### PR TITLE
Restrict `config` updating via querystring to development and `config.features`

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -1,11 +1,11 @@
 // Internal dependencies
 import languages from './languages';
-import { applyQueryStringToConfig } from 'lib/config';
+import { applyQueryStringToFeatures } from 'lib/config';
 
 const NODE_ENV = process.env.NODE_ENV,
 	productionOnly = NODE_ENV === 'production';
 
-let config = {
+const config = {
 	available_tlds: [ 'blog' ],
 	default_tld: 'blog',
 	default_search_sort: 'recommended',
@@ -44,7 +44,8 @@ let config = {
 };
 
 if ( typeof window !== 'undefined' && window.location && window.location.search ) {
-	config = applyQueryStringToConfig( config, window.location.search );
+	// allow us to update `config.features` with the query string only in development
+	config.features = applyQueryStringToFeatures( config.features, window.location.search );
 }
 
 export default function( key ) {

--- a/app/lib/config/tests/index.js
+++ b/app/lib/config/tests/index.js
@@ -1,7 +1,7 @@
 jest.disableAutomock();
 
 // Internal dependencies
-import { getQueryParams, applyQueryStringToConfig } from '../index';
+import { getQueryParams, applyQueryStringToFeatures } from '../index';
 
 describe( 'lib/config', () => {
 	describe( '#getQueryParams', () => {
@@ -35,29 +35,33 @@ describe( 'lib/config', () => {
 		} );
 	} );
 
-	describe( '#applyQueryStringToConfig', () => {
-		it( 'should return the same config object is no query string is given', () => {
-			const config = {
+	describe( '#applyQueryStringToFeatures', () => {
+		it( 'should return the same features object is no query string is given', () => {
+			const features = {
 				foo: true,
 				hello: 'world'
 			};
-			const result = applyQueryStringToConfig( config );
+			const result = applyQueryStringToFeatures( features );
 
-			expect( result ).toEqual( config );
+			expect( result ).toEqual( features );
 		} );
 
-		it( 'should modify the config using the query string content', () => {
+		it( 'should modify the `features` of `config` using the query string content', () => {
 			const config = {
-				foo: false,
+				features: {
+					foo: false,
+					bar: false,
+					baz: true,
+				},
 				hello: 'world',
 				x: 54
 			};
-			const result = applyQueryStringToConfig( config, '?foo=baz&x=56' );
+			const result = applyQueryStringToFeatures( config.features, '?features.foo&features.bar=true&features.baz=false' );
 
 			expect( result ).toEqual( {
-				foo: 'baz',
-				hello: 'world',
-				x: 56
+				foo: true,
+				bar: true,
+				baz: false,
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR:

- Updates `lib/config` such that only `config.features` is updated by parameters in the query string.
- Updates `config` such that features are only updated when Delphin is run in development.

I decided to limit this to `config.features` because that seems like the main use case, and because it is namespaced under `features.` we don't need to worry about conflicts with other query string params in the app.

**Note:** The last commit fails on purpose, was added for testing, and should be removed before this branch is merged.

**Testing**
- Visit http://delphin.localhost:1337/?features.test_query_flag and assert that you see an alert with the content `it is working!`.
- Visit http://delphin.localhost:1337/ and assert that you do not see this alert.

- [ ] Code
- [ ] Product

cc @Tug - we'll either need to give `delphin.live` its own environment variable if we want this behavior there, or find another solution.