### PR TITLE
Normalize queries and force-lowercase keyword inputs.

### DIFF
--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -62,7 +62,7 @@ const Search = React.createClass( {
 	},
 
 	redirectToSearch( query ) {
-		this.props.redirectToSearch( normalizeDomain( query ), this.props.numberOfResultsToDisplay, this.props.sort );
+		this.props.redirectToSearch( query, this.props.numberOfResultsToDisplay, this.props.sort );
 	},
 
 	selectDomain( suggestion ) {
@@ -74,7 +74,7 @@ const Search = React.createClass( {
 
 		return ! isRequesting &&
 			isDomainSearch( query ) &&
-			results && ! queryIsInResults( results, query );
+			results && ! queryIsInResults( results, normalizeDomain( query ) );
 	},
 
 	renderDomainUnavailableMessage() {

--- a/app/components/ui/search/suggestions.js
+++ b/app/components/ui/search/suggestions.js
@@ -4,7 +4,7 @@ import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
-import { omitTld } from 'lib/domains';
+import { normalizeDomain, omitTld } from 'lib/domains';
 import styles from './styles.scss';
 import Suggestion from 'components/containers/suggestion';
 
@@ -75,7 +75,7 @@ const Suggestions = React.createClass( {
 					.slice( 0, this.props.count )
 					.map( ( suggestion ) => (
 					<Suggestion
-						isBestMatch={ omitTld( this.props.query.replace( /\s+/g, '' ) ) === omitTld( suggestion.domainName ) }
+						isBestMatch={ omitTld( normalizeDomain( this.props.query.replace( /\s+/g, '' ) ) ) === omitTld( suggestion.domainName ) }
 						key={ suggestion.domainName }
 						selectDomain={ this.props.selectDomain }
 						suggestion={ suggestion }

--- a/app/components/ui/sunrise-home/index.js
+++ b/app/components/ui/sunrise-home/index.js
@@ -12,7 +12,6 @@ import styles from './styles.scss';
 import ValidationError from 'components/ui/form/validation-error';
 import withPageView from 'lib/analytics/with-page-view';
 import Input from 'components/ui/form/input';
-import { normalizeDomain } from 'lib/domains';
 
 const SunriseHome = React.createClass( {
 	propTypes: {
@@ -25,7 +24,7 @@ const SunriseHome = React.createClass( {
 	},
 
 	handleSubmit() {
-		const query = normalizeDomain( this.props.values.q );
+		const query = this.props.values.q;
 
 		this.props.redirectToSearch( query );
 	},


### PR DESCRIPTION
Fix for #1029 

#### Testing instructions

1. Run `git checkout fix/keyword-normalization`
2. Open home page
3. Enter "Noel.blog" in the search field
4. On the `/search` page, assert that the keyword entered (with the green background at the top) says "Noel.blog" (not lowercased)
5. Still on `/search` page, assert that the query in the URL is not lowercased (`http://delphin.localhost:1337/search?q=Noel.blog`)
6. Still on `/search` page, assert that there's no error message that says "Noel.blog is not available, try these suggestions instead"
7. Still on `/search` page, assert that noel.blog is listed first as the available domain name, and has the "Best Match" label.
8. Still on `/search` page, enter a new keyword on the search field using different capitalization ("TeSt" for example). Hit enter. Assert that both the query on the URL (`/search?q=Noel.blog+TeSt`) and the newly added keyword in green background are not lowercased
9. Still on `/search` page, delete all current keywords until the search bar is empty
10. Still on `/search` page, Type a new keyword: "TeSt.blog". Hit enter. Assert that both the query on the URL (`/search?q=TeSt.blog`) and the newly added keyword in green background are not lowercased
11. (Optional) Repeat step 2-6 using different keywords with varying capitalization)

#### Reviews

- [x] Code
- [x] Product
 
