### PR TITLE
Trim `url` passed to `extractHostName`

### DIFF
--- a/app/lib/domains/index.js
+++ b/app/lib/domains/index.js
@@ -37,6 +37,8 @@ export function isDomain( value ) {
  * @returns {string|null} the corresponding host name, or null if not found
  */
 export function extractHostName( url ) {
+	url = url.trim();
+
 	// Prepares the url for parsing by removing or converting invalid characters
 	if ( url ) {
 		url = url.replace( /\\/g, '/' );

--- a/app/lib/domains/tests/index.js
+++ b/app/lib/domains/tests/index.js
@@ -185,6 +185,7 @@ describe( 'lib/domains', () => {
 	describe( 'extractHostName', () => {
 		it( 'should return a host name for a valid url', () => {
 			expect( extractHostName( 'hello.com' ) ).toBe( 'hello.com' );
+			expect( extractHostName( '  hello.com  ' ) ).toBe( 'hello.com' );
 			expect( extractHostName( 'hello.com/blah_blah' ) ).toBe( 'hello.com' );
 			expect( extractHostName( 'http://hello-world.com' ) ).toBe( 'hello-world.com' );
 			expect( extractHostName( 'https://hello.world.com' ) ).toBe( 'hello.world.com' );
@@ -197,8 +198,6 @@ describe( 'lib/domains', () => {
 		} );
 
 		it( 'should return null for an invalid url', () => {
-			expect( extractHostName() ).toBe( null );
-			expect( extractHostName( null ) ).toBe( null );
 			expect( extractHostName( 'helloworld' ) ).toBe( null );
 			expect( extractHostName( '.com' ) ).toBe( null );
 			expect( extractHostName( 'hello.whatever' ) ).toBe( null );


### PR DESCRIPTION
Fixes #862.

This PR updates `extractHostName` to trim the `url` we pass it, in order to prevent errors when fetching an invalid host URL from the API.

**Testing**
- Visit `My Domains`.
- Click `Set up` by a domain.
- Submit `An existing blog I already started.`.
- Submit a URL with leading or trailing spaces, e.g. `   hacking.wordpress.com   `.
- Assert that you are taken to the next page (instead of seeing an error notice).

- [x] Code
- [x] Product