### PR TITLE
Fix the target=_blank vulnerability

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
 		// REST API objects include underscores
 		'camelcase': 0,
 		// Custom PropTypes checks
+		'react/jsx-no-target-blank': 1,
 		'react/prop-types': 2,
 		'react/sort-prop-types': 2,
 
@@ -20,7 +21,6 @@ module.exports = {
 		'max-len': 0,
 		'no-console': 0,
 		'prefer-const': 0,
-		'react/jsx-no-target-blank': 0,
 		'react/prefer-es6-class': 0,
 		'quote-props': 0,
 		'wpcalypso/import-docblock': 0,

--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -329,7 +329,7 @@ const Checkout = React.createClass( {
 								{ i18n.translate( 'By clicking "Register & pay now" you agree to our {{link}}domain name registration agreement{{/link}}. You also authorize your payment method to be charged on a recurring basis, until you cancel.',
 									{
 										components: {
-											link: <a href="https://wordpress.com/automattic-domain-name-registration-agreement/" target="_blank" />
+											link: <a href="https://wordpress.com/automattic-domain-name-registration-agreement/" target="_blank" rel="noopener noreferrer" />
 										}
 									}
 								) }

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -70,7 +70,7 @@ const ConnectUser = React.createClass( {
 				{ i18n.translate( 'By clicking Next, you understand that you will get a WordPress.com account as a part of signing up at get.blog, and agree to these ' +
 				'{{link}}Terms of Service{{/link}}.',
 					{
-						components: { link: <a href="https://wordpress.com/tos/" target="_blank" /> }
+						components: { link: <a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" /> }
 					}
 				) }
 			</section>;


### PR DESCRIPTION
This pull request fixes #1006 by adding `rel="noopener noreferrer"` to all external links. It also adds this rule to the ESLint rules to prevent us from adding more non-compliant links in future.
  
#### Testing instructions
  
1. Run `git checkout fix/target_blank` and start your server, or open a [live branch](https://delphin.live/?branch=fix/target_blank)
2. Run `npm run lint` and check the tests pass
3. Start your server and check that the TOS and `domain name registration agreement` links work
  
#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed