### PR TITLE
Add `getRouteSlug`

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -13,7 +13,7 @@ import SearchContainer from 'components/containers/search';
 import SignupContainer from 'components/containers/connect-user/signup';
 import SunriseHomeContainer from 'components/containers/sunrise-home';
 import VerifyUserContainer from 'components/containers/connect-user/verify';
-import { buildPaths, getLocalizedRoutes } from 'lib/routes';
+import { buildPaths, getLocalizedRoutes, stripLocaleSlug } from 'lib/routes';
 import { verifyUserWithQueryContainerFactory } from 'components/containers/verify-user-with-query-container-factory';
 import { getComponent } from 'sections';
 
@@ -279,6 +279,8 @@ export const getRouteSlug = ( path, overrideRoutes ) => {
 		pathMap = buildPaths( overrideRoutes );
 	}
 
+	const pathWithoutLocaleSlug = stripLocaleSlug( path );
+
 	return find( Object.keys( pathMap ), slug => {
 		const currentPath = pathMap[ slug ];
 		const regexString = currentPath
@@ -287,6 +289,6 @@ export const getRouteSlug = ( path, overrideRoutes ) => {
 
 		const regexForPath = new RegExp( '^' + regexString + '$' );
 
-		return path.match( regexForPath );
+		return pathWithoutLocaleSlug.match( regexForPath );
 	} );
 };

--- a/app/tests/routes.js
+++ b/app/tests/routes.js
@@ -132,5 +132,10 @@ describe( 'routes', () => {
 			expect( getRouteSlug( '/foo/bar/optional-param', routes ) ).toBe( 'bar' );
 			expect( getRouteSlug( '/post/1/optional-param', routes ) ).toBe( 'post' );
 		} );
+
+		it( 'should ignore the locale slug in a given path', () => {
+			expect( getRouteSlug( '/ja/foo/bar/optional-param', routes ) ).toBe( 'bar' );
+			expect( getRouteSlug( '/fr/post/1/optional-param', routes ) ).toBe( 'post' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #1041.

Instead of storing the current route slug in state and keeping it in sync with the current path, I think we should just determine it from the map of slugs → paths that we already had to build to create `getPath`. @yurynix raised the concern that we're duplicating logic that must exist (somewhere) in `react-router`, but it isn't well exposed and we've already written most of the logic necessary for this with `buildPaths`.

**Testing**
This adds a function that we'll use in #1035 (and eventually elsewhere) so only a code review is needed.