### PR TITLE
Framework: Automatically return to the url which enforced sign up

### DIFF
--- a/app/actions/routes.js
+++ b/app/actions/routes.js
@@ -1,5 +1,5 @@
 // External dependencies
-import { push } from 'react-router-redux';
+import { push, replace } from 'react-router-redux';
 
 // Internal dependencies
 import { getPath } from 'app/routes';
@@ -7,12 +7,12 @@ import { getPath } from 'app/routes';
 /***
  * Creates a redirect push action
  * @param {string} pathSlug a path slug as appears in route definitions
- * @param {{queryParams: string, pathParams:string}} options object that has queryParams - key value pairs of query
+ * @param {{queryParams: string, pathParams:string, state: string}} options object that has queryParams - key value pairs of query
  * parameters and pathParams a route parameters as defined in routes definitions
  * @returns {Object} push redirect action
  */
 export const redirect = ( pathSlug, options = {} ) => {
-	const { queryParams, pathParams } = options;
+	const { queryParams, pathParams, noHistory, state } = options;
 
 	const locationDescriptor = {
 		pathname: getPath( pathSlug, pathParams )
@@ -20,6 +20,14 @@ export const redirect = ( pathSlug, options = {} ) => {
 
 	if ( queryParams ) {
 		locationDescriptor.query = queryParams;
+	}
+
+	if ( state ) {
+		locationDescriptor.state = state;
+	}
+
+	if ( noHistory ) {
+		return replace( locationDescriptor );
 	}
 
 	return push( locationDescriptor );

--- a/app/components/containers/connect-user/index.js
+++ b/app/components/containers/connect-user/index.js
@@ -47,13 +47,6 @@ export default reduxForm(
 			( fields, domain ) => connectUser( fields.email, ownProps.intention, domain )
 		),
 		redirectToHome: () => redirect( 'home' ),
-		redirectToVerifyUser: () => {
-			const { location: { query } } = ownProps,
-				// omit the query params entirely if empty to prevent an empty
-				// `?redirect_to=` at the end of the URL
-				queryParams = query.redirect_to ? { redirect_to: query.redirect_to } : undefined;
-
-			return redirect( 'verifyUser', { queryParams } );
-		}
+		redirectToVerifyUser: () => redirect( 'verifyUser', { noHistory: true, state: ownProps.location.state } )
 	}, dispatch )
 )( ConnectUser );

--- a/app/components/containers/connect-user/verify.js
+++ b/app/components/containers/connect-user/verify.js
@@ -2,7 +2,7 @@
 import { bindActionCreators } from 'redux';
 import capitalize from 'lodash/capitalize';
 import { change, reduxForm } from 'redux-form';
-import { push } from 'react-router-redux';
+import { replace } from 'react-router-redux';
 
 // Internal dependencies
 import { addNotice } from 'actions/notices';
@@ -61,7 +61,13 @@ export default reduxForm(
 		} ),
 		recordPageView,
 		redirect,
-		redirectToQueryParamUrl: () => push( ownProps.location.query.redirect_to ),
+		redirectLoggedIn: () => {
+			if ( ownProps.location.state.returnTo ) {
+				return replace( ownProps.location.state.returnTo );
+			}
+
+			return redirect( 'myDomains' );
+		},
 		selectDomain,
 		showToggle,
 		updateCode: code => change( 'verifyUser', 'code', code ),

--- a/app/components/containers/contact-information.js
+++ b/app/components/containers/contact-information.js
@@ -42,9 +42,9 @@ export default reduxForm(
 		domain: getSelectedDomain( state ),
 		hasSelectedDomain: hasSelectedDomain( state ),
 		inputVisibility: inputVisibility( state ),
-		location: getUserLocation( state ),
 		states: getStates( state, get( state, 'form.contactInformation.countryCode.value' ) ),
-		user: getUserSettings( state )
+		user: getUserSettings( state ),
+		userLocation: getUserLocation( state )
 	} ),
 	dispatch => (
 		bindActionCreators( {
@@ -62,4 +62,4 @@ export default reduxForm(
 			validateContactInformation: ( domainName, contactInformation ) => validateContactInformation( [ domainName ], contactInformation )
 		}, dispatch )
 	)
-)( RequireSignup( ContactInformation, getPath( 'contactInformation' ) ) );
+)( RequireSignup( ContactInformation ) );

--- a/app/components/containers/require-signup.js
+++ b/app/components/containers/require-signup.js
@@ -11,7 +11,7 @@ function getDisplayName( WrappedComponent ) {
 	return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 
-export default ( WrappedComponent, redirectTo ) => {
+export default ( WrappedComponent ) => {
 	class SignupEnforcer extends Component {
 		componentWillMount() {
 			if ( this.props.isLoggedOut ) {
@@ -51,11 +51,12 @@ export default ( WrappedComponent, redirectTo ) => {
 			isLoggedIn: isLoggedIn( state ),
 			isLoggedOut: isLoggedOut( state )
 		} ),
-		dispatch => ( {
+		( dispatch, ownProps ) => ( {
 			redirectToSignup() {
 				dispatch( redirect( 'signupUser', {
-					queryParams: {
-						redirect_to: redirectTo
+					noHistory: true,
+					state: {
+						returnTo: ownProps.location.pathname
 					}
 				} ) );
 			}

--- a/app/components/ui/connect-user/verify-user/index.js
+++ b/app/components/ui/connect-user/verify-user/index.js
@@ -30,7 +30,7 @@ const VerifyUser = React.createClass( {
 		query: PropTypes.object,
 		recordPageView: PropTypes.func.isRequired,
 		redirect: PropTypes.func.isRequired,
-		redirectToQueryParamUrl: PropTypes.func.isRequired,
+		redirectLoggedIn: PropTypes.func.isRequired,
 		redirectToTryWithDifferentEmail: PropTypes.func.isRequired,
 		selectDomain: PropTypes.func.isRequired,
 		showToggle: PropTypes.func.isRequired,
@@ -75,11 +75,7 @@ const VerifyUser = React.createClass( {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.isLoggedIn ) {
-			if ( nextProps.query.redirect_to ) {
-				this.props.redirectToQueryParamUrl();
-			} else {
-				this.props.redirect( 'myDomains' );
-			}
+			nextProps.redirectLoggedIn();
 		}
 	},
 

--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -27,7 +27,7 @@ class ContactInformation extends React.Component {
 			return;
 		}
 
-		if ( ! this.props.location.isRequesting && ! this.props.location.hasLoadedFromServer ) {
+		if ( ! this.props.userLocation.isRequesting && ! this.props.userLocation.hasLoadedFromServer ) {
 			this.props.fetchLocation();
 		}
 
@@ -98,8 +98,8 @@ class ContactInformation extends React.Component {
 		let countryCode;
 
 		// Use the GEO location
-		if ( props.location.hasLoadedFromServer ) {
-			countryCode = props.location.data.countryCode;
+		if ( props.userLocation.hasLoadedFromServer ) {
+			countryCode = props.userLocation.data.countryCode;
 		}
 
 		if ( props.contactInformation.hasLoadedFromServer && props.contactInformation.data.countryCode ) {
@@ -114,7 +114,7 @@ class ContactInformation extends React.Component {
 
 	canUpdateCountryFromLocation( props = this.props ) {
 		return ! this.isDataLoading( props ) &&
-			( props.location.hasLoadedFromServer || props.location.hasFailedToLoad );
+			( props.userLocation.hasLoadedFromServer || props.userLocation.hasFailedToLoad );
 	}
 
 	shouldFetchStates( nextProps ) {
@@ -393,7 +393,6 @@ ContactInformation.propTypes = {
 	hasSelectedDomain: PropTypes.bool.isRequired,
 	inputVisibility: PropTypes.object.isRequired,
 	invalid: PropTypes.bool.isRequired,
-	location: PropTypes.object.isRequired,
 	redirectToCheckout: PropTypes.func.isRequired,
 	redirectToHome: PropTypes.func.isRequired,
 	resetInputVisibility: PropTypes.func.isRequired,
@@ -403,6 +402,7 @@ ContactInformation.propTypes = {
 	submitting: PropTypes.bool.isRequired,
 	untouch: PropTypes.func.isRequired,
 	user: PropTypes.object.isRequired,
+	userLocation: PropTypes.object.isRequired,
 	validateContactInformation: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
This is my proposal which resolves two issues with the current signup flow when user wants to purchases domain:
- we need to explicitly provide return url which is used after users is logged in
- it's not possible to use browser back button to go back from Contact Information page to Search page after user has logged in using signup flow.

How it works witch changes applied:

![singup-login-clean-history](https://cloud.githubusercontent.com/assets/699132/20965724/5cd728dc-bc77-11e6-93ee-c13b12b4fcc0.gif)

We never store in browser's history pages related to sign up. After user gets logged in, they can navigate back to the previous page. In this particular example user can go back from Contact Information page to the Search page.

/cc @drewblaisdell @yurynix @Automattic/sdev-feed 