### PR TITLE
We should emphasize that keywords are not translatable

### DIFF
--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -100,7 +100,12 @@ const Search = React.createClass( {
 		return (
 			<LoadingPlaceholder
 				isStatic
-				text={ i18n.translate( 'Nothing found. Try entering a few words above, like "pet travel blog".' ) }
+				text={ i18n.translate( 'Nothing found. Try entering a few words above, like "%(keywords)s".', {
+					args: {
+						keywords: 'pet travel blog'
+					},
+					comment: "keywords are example keywords and shouldn't be translated"
+				} ) }
 			/>
 		);
 	},


### PR DESCRIPTION
This pull request adds a comment for translators not to translate
the search keywords.
 
#### Testing instructions
  
1. Run `git checkout fix/translation-comment` and start your server, or open a [live branch](https://delphin.live/?branch=fix/translation-comment)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that everything works as normal, this PR should have no effect
  
#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed
