### PR TITLE
Fix display issue with progress bar

### DIFF
--- a/app/components/ui/checkout-progressbar/styles.scss
+++ b/app/components/ui/checkout-progressbar/styles.scss
@@ -10,7 +10,7 @@ $inner-dot-color: $gray-xlight;
 .progressbar {
 	display: flex;
 	margin: 0 auto;
-	max-width: 320px;
+	max-width: 400px;
 }
 
 @mixin step-line-style( $color, $width ) {
@@ -28,7 +28,7 @@ $inner-dot-color: $gray-xlight;
 	display: flex;
 	flex: 1;
 	flex-direction: column;
-	justify-content: center;
+	justify-content: flex-end;
 	position: relative;
 
 	&::after {


### PR DESCRIPTION
Fixes #1026. I increased the width of the progress bar so no languages wrap to two lines at full size. But I also fixed the underlying display issue with the alignment of the dots to future-proof.

#### Screenshots

Before | After
------------ | -------------
![image](https://cloud.githubusercontent.com/assets/448298/20994741/5a970eb8-bcc0-11e6-814a-0f47648e624a.png) | ![image](https://cloud.githubusercontent.com/assets/448298/20994735/48a6e890-bcc0-11e6-8757-07b3aa76aea2.png)


#### Testing

* Change language to French
* Go through checkout flow
* Assert the progress bar displays correctly

#### Review

- [ ] Code
- [x] Product