### PR TITLE
Update Success page to display a different message for trademarked domains

### DIFF
--- a/app/components/containers/success.js
+++ b/app/components/containers/success.js
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 import { checkDomainAvailability } from 'actions/domain-availability';
 import { destroySetupForms } from 'actions/setup';
 import { fetchMyDomains } from 'actions/my-domains';
+import { getContactInformationEmail } from 'reducers/form/selectors';
 import { getSelectedDomain } from 'reducers/checkout/selectors';
 import { hasDomainTrademarkClaim } from 'reducers/domain-availability/selectors';
 import { hasDomainAvailabilityLoaded } from 'reducers/domain-availability/selectors';
@@ -14,10 +15,12 @@ import Success from 'components/ui/success';
 
 export default connect(
 	state => {
-		const domainName = getSelectedDomain( state ).domainName;
+		const domainName = getSelectedDomain( state ).domainName,
+			email = getContactInformationEmail( state );
 
 		return {
 			domain: domainName,
+			email: email,
 			hasTrademarkClaim: hasDomainTrademarkClaim( state, domainName ),
 			hasDomainAvailabilityLoaded: hasDomainAvailabilityLoaded( state, domainName ),
 		};

--- a/app/components/ui/success/index.js
+++ b/app/components/ui/success/index.js
@@ -26,22 +26,30 @@ class Success extends React.Component {
 	}
 
 	renderTrademarkedDomain() {
+		const { email } = this.props;
+
 		return (
 			<div>
 				<div className={ styles.content }>
 					<div className={ styles.text }>
 						<p>
 							{ i18n.translate(
-								'You will get an email soon to review the Trademark Notice on this domain. ' +
-								'You must verify with Trademark Clearinghouse that your registration of this domain ' +
-								'will not infringe on the trademark.'
+								'We sent you an email to %(email)s with instructions for reviewing the trademark claim on this domain.', {
+									args: { email },
+								}
 							) }
 						</p>
 
 						<p>
 							{ i18n.translate(
-								'If you do not review and respond to this request within 48 hours ' +
-								'your registration will be cancelled.'
+								'To complete the registration, please review the terms and agree to them within 48 hours.'
+							) }
+						</p>
+
+						<p>
+							{ i18n.translate(
+								'If you reject the terms, or if you don’t agree to them on time, ' +
+								'your order will be canceled and you will be refunded automatically.'
 							) }
 						</p>
 					</div>
@@ -143,6 +151,7 @@ Success.propTypes = {
 	checkDomainAvailability: PropTypes.func.isRequired,
 	destroySetupForms: PropTypes.func.isRequired,
 	domain: PropTypes.string,
+	email: PropTypes.string,
 	fetchMyDomains: PropTypes.func.isRequired,
 	hasDomainAvailabilityLoaded: PropTypes.bool.isRequired,
 	hasTrademarkClaim: PropTypes.bool.isRequired

--- a/app/reducers/form/selectors.js
+++ b/app/reducers/form/selectors.js
@@ -20,3 +20,13 @@ export const getBlogType = ( state ) => {
 export const getBlogNeedSelected = ( state ) => {
 	return get( state, 'form.selectNewBlogNeeds.needs.value' );
 };
+
+/**
+ * Retrieves the email address the user entered in the contact information form
+ *
+ * @param {object} state - global state tree
+ * @returns {string|null} - the email address from the contact information form
+ */
+export const getContactInformationEmail = ( state ) => {
+	return get( state, 'form.contactInformation.email.value' );
+};


### PR DESCRIPTION
Update succes page according to https://github.com/Automattic/delphin/issues/978

### Testing Instructions
- Purchase a trademarked domain (such as `sparkplug.blog`)
- Ensure the success page matches the specifications
- Check that the default success page is still valid

### Reviews
- [x] Code
- [x] Product
