### PR TITLE
Fix search bar overlap on mid-size screens

### DIFF
--- a/app/components/ui/search/styles.scss
+++ b/app/components/ui/search/styles.scss
@@ -308,7 +308,7 @@
 	}
 
 	@include breakpoint( '<660px' ) {
-		margin-top: 61px;
+		margin-top: 81px;
 	}
 
 	@include breakpoint( '<480px' ) {


### PR DESCRIPTION
Fixes #1019 

Before | After
------------ | -------------
![image](https://cloud.githubusercontent.com/assets/448298/21062623/b91309b4-be1f-11e6-8884-ac9a832df3e5.png) | ![image](https://cloud.githubusercontent.com/assets/448298/21062605/ac452a96-be1f-11e6-9bed-85eb8fc38b5a.png)


#### Testing

* Search for a domain
* Make sure your viewport is between 480px and 660px
* Assert the search bar doesn't overlap the sort options

#### Review

- [x] Code
- [x] Product