### PR TITLE
Normalize nameserver domain name

### DIFF
--- a/app/components/containers/set-up-domain/update-nameservers.js
+++ b/app/components/containers/set-up-domain/update-nameservers.js
@@ -6,13 +6,21 @@ import { goBack } from 'react-router-redux';
 import { addNotice } from 'actions/notices';
 import { getAsyncValidateFunction } from 'lib/form';
 import { redirect } from 'actions/routes';
-import UpdateNameservers from 'components/ui/set-up-domain/update-nameservers';
+import UpdateNameserversComponent from 'components/ui/set-up-domain/update-nameservers';
 import { isRequestingNameservers } from 'reducers/nameservers/selectors';
 import { validateUpdateNameserversForm } from 'lib/domains/nameservers';
 import { fetchNameservers, updateNameservers } from 'actions/nameservers';
 import RequireLogin from 'components/containers/require-login';
 
-export default reduxForm(
+const trimLowerCase = value => value && value.trim().toLowerCase();
+export const formNormalizers = {
+	nameserver1: trimLowerCase,
+	nameserver2: trimLowerCase,
+	nameserver3: trimLowerCase,
+	nameserver4: trimLowerCase,
+};
+
+export const UpdateNameservers = reduxForm(
 	{
 		form: 'nameservers',
 		fields: [
@@ -34,4 +42,4 @@ export default reduxForm(
 		fetchNameservers,
 		goBack
 	}
-)( RequireLogin( UpdateNameservers ) );
+)( RequireLogin( UpdateNameserversComponent ) );

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -15,13 +15,19 @@ import { service } from './service';
 import ui from './ui';
 import { user } from './user';
 
+import { formNormalizers as nameserversNormalizers } from 'components/containers/set-up-domain/update-nameservers';
+
+const formsNormalizersMap = {
+	nameservers: nameserversNormalizers
+};
+
 export default {
 	checkout,
 	contactInformation,
 	contactSupport,
 	domainAvailability,
 	domainSearch,
-	form,
+	form: form.normalize( formsNormalizersMap ),
 	nameservers,
 	notices,
 	prices,

--- a/app/sections/set-up-domain.js
+++ b/app/sections/set-up-domain.js
@@ -10,7 +10,7 @@ import findExistingBlog from 'components/containers/set-up-domain/find-existing-
 import selectBlogType from 'components/containers/set-up-domain/select-blog-type';
 import selectNewBlogHost from 'components/containers/set-up-domain/select-new-blog-host';
 import selectNewBlogNeeds from 'components/containers/set-up-domain/select-new-blog-needs';
-import updateNameservers from 'components/containers/set-up-domain/update-nameservers';
+import { UpdateNameservers as updateNameservers } from 'components/containers/set-up-domain/update-nameservers';
 
 export default {
 	confirmConnectBlog,


### PR DESCRIPTION
This pull request fixes #1011 by adding normalizers to redux form
  
#### Testing instructions
  
1. Run `git checkout fix/remove-lowercase-validation` and start your server, or open a [live branch](https://delphin.live/?branch=fix/remove-lowercase-validation)
2. Open the [`My Domains` page](http://delphin.localhost:1337/my-domains)
3. Click on some domain, click on `Have your own name servers? Configure manually.`
4. Input (directly or copy paste) a NS1.WordPress.COM with and without leading/trailing spaces
5. Validate input is trimmed and lowercased
  
#### Reviews
  
- [ ] Code
- [ ] Product
   
@Automattic/sdev-feed
