### PR TITLE
Confirm Trademark: copy update

### DIFF
--- a/app/components/ui/confirm-trademark/index.js
+++ b/app/components/ui/confirm-trademark/index.js
@@ -100,10 +100,10 @@ class ConfirmTrademark extends React.Component {
 				<Form className={ styles.form } onSubmit={ this.handleSubmit }>
 					<Form.FieldArea>
 						<p>
-							{ i18n.translate( 'You can register this domain, but you will have to confirm that your registration will not infringe on the trademark rights. The trademark holder will be notified, and they may choose to dispute your registration.' ) }
+							{ i18n.translate( 'To register this domain, you must agree to the terms of the trademark claim. The trademark holder will be notified, and they may choose to dispute your registration.' ) }
 						</p>
 						<p>
-							{ i18n.translate( "We'll send you an email with further instructions after you submit your order. You will have to review the terms and agree to them within 48 hours, or your registration will be canceled." ) }
+							{ i18n.translate( "We'll send you an email with further instructions after you submit your order." ) }
 						</p>
 					</Form.FieldArea>
 
@@ -114,7 +114,7 @@ class ConfirmTrademark extends React.Component {
 					</Form.SubmitArea>
 
 					<Form.Footer>
-						<p>{ i18n.translate( "You'll get an automatic refund if you reject the terms or if you don't agree to them on time." ) }</p>
+						<p>{ i18n.translate( "Please review the terms and agree to them within 48 hours. You'll get an automatic refund if you reject the terms or if you don't agree to them on time." ) }</p>
 					</Form.Footer>
 				</Form>
 


### PR DESCRIPTION
Fixes #1070.

#### Testing instructions

1. `git checkout fix/paragraphs-confirm-tm`
2. Open the [`Home` page](http://delphin.localhost:1337/) and enter `tacobell.blog` in the search field.
3. Select the exact match suggestion in the results.
4. On `/confirm-trademark/tacobell.blog`, make sure that the copy matches the suggestion in #1070.

Before | After
------------ | -------------
![before](https://cloud.githubusercontent.com/assets/1248436/21143343/9759c0ea-c146-11e6-868d-d6ce96039057.png) | ![after](https://cloud.githubusercontent.com/assets/1248436/21143346/9905dfc8-c146-11e6-8e2d-d0265307cedd.png)

@Automattic/sdev-feed

#### Reviews

- [x] Code
- [x] Product
 
