### PR TITLE
Search: Exact match should disply domain taken card

### DIFF
--- a/app/components/ui/search/index.js
+++ b/app/components/ui/search/index.js
@@ -8,7 +8,7 @@ const Gridicon = require( '@automattic/dops-components/client/components/gridico
 // Internal dependencies
 import config from 'config';
 import DocumentTitle from 'components/ui/document-title';
-import { containsAlphanumericCharacters, isValidSecondLevelDomain, queryIsInResults, normalizeDomain } from 'lib/domains';
+import { containsAlphanumericCharacters, isSearchForDomainWithAvailableTld, isValidSecondLevelDomain, queryIsInResults, normalizeDomain } from 'lib/domains';
 import LoadingPlaceholder from './loading-placeholder';
 import styles from './styles.scss';
 import Suggestions from './suggestions';
@@ -73,7 +73,7 @@ const Search = React.createClass( {
 		const { query, isRequesting, results } = this.props;
 
 		return ! isRequesting &&
-			isValidSecondLevelDomain( query ) &&
+			( isValidSecondLevelDomain( query ) || isSearchForDomainWithAvailableTld( query ) ) &&
 			results && ! queryIsInResults( results, normalizeDomain( query ) );
 	},
 

--- a/app/lib/domains/index.js
+++ b/app/lib/domains/index.js
@@ -101,7 +101,7 @@ export function secondLevelDomainOf( validDomain ) {
  * @param {string} value - the string to test
  * @returns {boolean}    - the result of the test
  */
-export function isDomainSearch( value ) {
+export function isSearchForDomainWithAvailableTld( value ) {
 	return isDomain( value ) && domainEndsInAvailableTldRegEx.test( value );
 }
 

--- a/app/lib/domains/tests/index.js
+++ b/app/lib/domains/tests/index.js
@@ -2,7 +2,7 @@
 import {
 	extractHostName,
 	isDomain,
-	isDomainSearch,
+	isSearchForDomainWithAvailableTld,
 	isValidSecondLevelDomain,
 	secondLevelDomainOf,
 	omitTld,
@@ -107,24 +107,24 @@ describe( 'lib/domains', () => {
 		} );
 	} );
 
-	describe( 'isDomainSearch', () => {
+	describe( 'isSearchForDomainWithAvailableTld', () => {
 		it( 'should return true for valid .blog domains', () => {
-			expect( isDomainSearch( 'foo.blog' ) ).toBe( true );
-			expect( isDomainSearch( 'foo-bar.blog' ) ).toBe( true );
-			expect( isDomainSearch( 'foo0.blog' ) ).toBe( true );
+			expect( isSearchForDomainWithAvailableTld( 'foo.blog' ) ).toBe( true );
+			expect( isSearchForDomainWithAvailableTld( 'foo-bar.blog' ) ).toBe( true );
+			expect( isSearchForDomainWithAvailableTld( 'foo0.blog' ) ).toBe( true );
 		} );
 
 		it( 'should return false for invalid .blog domains', () => {
-			expect( isDomainSearch( 'foo-.blog' ) ).toBe( false );
-			expect( isDomainSearch( 'foo bar.blog' ) ).toBe( false );
+			expect( isSearchForDomainWithAvailableTld( 'foo-.blog' ) ).toBe( false );
+			expect( isSearchForDomainWithAvailableTld( 'foo bar.blog' ) ).toBe( false );
 		} );
 
 		it( 'should return false for non-.blog domains', () => {
-			expect( isDomainSearch( 'foo.com' ) ).toBe( false );
+			expect( isSearchForDomainWithAvailableTld( 'foo.com' ) ).toBe( false );
 		} );
 
 		it( 'should return false for strings without a TLD suffix', () => {
-			expect( isDomainSearch( 'foo' ) ).toBe( false );
+			expect( isSearchForDomainWithAvailableTld( 'foo' ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #1059.

### Before

* `java` shows that `java.blog` is taken: <img width="1280" alt="screen shot 2016-12-09 at 18 38 00" src="https://cloud.githubusercontent.com/assets/184938/21056667/48a1a86e-be3f-11e6-8d19-303c01060fd7.png">
* `java.blog` doesn't show the domain taken card: <img width="1269" alt="screen shot 2016-12-09 at 18 37 46" src="https://cloud.githubusercontent.com/assets/184938/21056684/6123caca-be3f-11e6-9276-2c6ce9df2654.png">


### After
* `java` shows that `java.blog` is taken: <img width="1280" alt="screen shot 2016-12-09 at 18 38 00" src="https://cloud.githubusercontent.com/assets/184938/21056667/48a1a86e-be3f-11e6-8d19-303c01060fd7.png">
* `java.blog` shows that `java.blog` is taken: 
<img width="1363" alt="screen shot 2016-12-13 at 20 06 27" src="https://cloud.githubusercontent.com/assets/699132/21154737/c0c02464-c16f-11e6-9393-f3c0510d6931.png">

### Testing
1. Go to http://delphin.localhost:1337/ or [Delphin live](https://delphin.live/?branch=fix/1059-exact-match).
2. Search for `java`.
3. Make sure you see the domain taken card.
4. Search for `java.blog`.
5. Make sure you see the domain taken card.
6. Search for `java.com`.
7. Make sure you DON'T see the domain taken card.

### Review
* [x] Code
* [x] Product
