### PR TITLE
Fix "Let's get started" alignment

### DIFF
--- a/app/components/ui/loading-screen/styles.scss
+++ b/app/components/ui/loading-screen/styles.scss
@@ -13,6 +13,7 @@
 	color: $blue-dark;
 	font: 400 2.6rem $body-font;
 	padding-top: 160px;
+	text-align: center;
 
 	@include breakpoint( '>480px' ) {
 		font-size: 2.4rem;


### PR DESCRIPTION
Fixes #1064 

Before | After
------------ | -------------
<img width="722" alt="screen shot 2016-12-13 at 20 10 11" src="https://cloud.githubusercontent.com/assets/448298/21165965/90aaadac-c170-11e6-81e6-16c0f7e196a8.png"> | <img width="720" alt="screen shot 2016-12-13 at 20 09 39" src="https://cloud.githubusercontent.com/assets/448298/21165961/8d79ee36-c170-11e6-80cd-9a76845b4aee.png">


#### Testing

* Visit `/log-in` and enter your email address
* Click the magic link in the email
* Assert the `Let's get started…` copy is centered

#### Review

- [x] Code
- [x] Product