### PR TITLE
Contact Information: Refine copy about whois

### DIFF
--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -182,10 +182,10 @@ class ContactInformation extends React.Component {
 		const { hasTrademarkClaim } = this.props;
 
 		if ( hasTrademarkClaim ) {
-			return i18n.translate( 'As a requirement of a trademarked domain, your contact information will be included in a public database of domain owners, called "Whois".' );
+			return i18n.translate( 'Your contact information will be available in a public database of domain owners, called "Whois".' );
 		}
 
-		return i18n.translate( 'To protect your identity and prevent spam, we keep your personal details hidden from the public.' );
+		return i18n.translate( "Domain owners are required to share contact information publicly. We keep your personal information out of your domain's public records, to protect your identity and prevent spam." );
 	}
 
 	render() {
@@ -221,14 +221,14 @@ class ContactInformation extends React.Component {
 								<fieldset>
 									<label>{ i18n.translate( 'First Name' ) }</label>
 									<Input
-											disabled={ this.isDataLoading() }
-											field={ fields.firstName }
-											autoFocus
-											untouch={ untouch }
-											className={ styles.firstName }
-											placeholder={ i18n.translate( 'First Name' ) }
-											dir="ltr"
-										/>
+										disabled={ this.isDataLoading() }
+										field={ fields.firstName }
+										autoFocus
+										untouch={ untouch }
+										className={ styles.firstName }
+										placeholder={ i18n.translate( 'First Name' ) }
+										dir="ltr"
+									/>
 									<ValidationError field={ fields.firstName } />
 								</fieldset>
 


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/delphin/pull/1069 that refines the copy displayed at the bottom of the `Contact Information` page, depending on the type of domain being registered:

##### Regular domains

<img width="450" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/21227679/3e962a2a-c2db-11e6-96cc-64467bef79a2.png">

##### Domains with trademark claim

<img width="454" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/21227697/54f8a69e-c2db-11e6-8ff3-cb08cf023c27.png">

#### Testing instructions

1. Run `git checkout update/contact-information` and start your server, or open a [live branch](https://delphin.live/?branch=update/contact-information)
2. Open the [`Search` page](http://delphin.localhost:1337/search) and select a regular domain
3. Proceed to the `Contact Information` page
4. Check that the copy matches the screenshot above
5. Repeat these steps for a domain with a trademark claim such as `seat.blog`

#### Reviews

- [x] Code
- [x] Product
 
@Automattic/sdev-feed
