### PR TITLE
CircleCI config: add support for LocalCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,3 +32,13 @@ test:
   override:
     - yarn test
     - yarn run lint
+  post:
+    - |
+      if [[ "$CIRCLE_BRANCH" != "master" ]]; then
+        git clone https://github.com/Automattic/gp-localci-client.git
+        bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
+        rm -rf gp-localci-client
+      fi
+notify:
+  webhooks:
+    - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh


### PR DESCRIPTION
This change adds the GP LocalCI “client” to facilitate string coverage reporting.

<img width="717" alt="screen-shot-2016-12-21-at-16-38-30" src="https://cloud.githubusercontent.com/assets/2006764/21460564/c405c020-c917-11e6-8c43-a3064624a123.png">

See: https://github.com/Automattic/gp-localci