### PR TITLE
Contact Information: Fix phone field not prefixed on country change

### DIFF
--- a/app/components/ui/form/phone/index.js
+++ b/app/components/ui/form/phone/index.js
@@ -26,7 +26,7 @@ class Phone extends React.Component {
 		if ( currentCountryCode !== nextCountryCode ) {
 			const currentCallingCode = getCallingCode( currentCountryCode );
 
-			if ( ! nextPhoneNumber || nextPhoneNumber === maskPhone( currentCallingCode ) ) {
+			if ( ! nextPhoneNumber || nextPhoneNumber === '+' || nextPhoneNumber === maskPhone( currentCallingCode ) ) {
 				const nextCallingCode = getCallingCode( nextCountryCode );
 
 				updatePhone( maskPhone( nextCallingCode ) );


### PR DESCRIPTION
Fixes #816:

> We should fix the case where the `Contact Information` page loads with fields prefilled from the user's profile. In that case, clearing the phone field and then switching of country doesn't add the corresponding country calling code to the phone field (i.e. this field stays blank):
> 
> ![screenshot](https://cloud.githubusercontent.com/assets/594356/19828408/4bf55aa0-9dc5-11e6-9eeb-d373cb120c25.png)

### Testing
1. Open http://delphin.localhost:1337 or https://delphin.live/?branch=fix/816-phone-update-country.
2. Make sure you are logged out.
3. Pick your domain.
4. Make sure that Phone Number is filled in with phone prefix each time you update Country field.
5. Once you enter Phone Number, this field should not update when Country field is updated.
6. Erase Phone Number.
7. Make sure that Phone Number is filled in with phone prefix again each time you update Country field.
8. Sign out.
9. Pick your domain.
10. Log in with existing account with Contact Information filled in.
11. Make sure Phone Number is filled in and it doesn't get updated when you change Country field.
12. Erase Phone Number.
13. Make sure that Phone Number is filled in with phone prefix again each time you update Country field.

### Review
* [x] Code
* [x] Product

@Automattic/sdev-feed 