### PR TITLE
Contact Information: Focus organization and address line fields when expanded

### DIFF
--- a/app/components/ui/contact-information/index.js
+++ b/app/components/ui/contact-information/index.js
@@ -255,6 +255,7 @@ class ContactInformation extends React.Component {
 									<fieldset>
 										<label>{ i18n.translate( 'Organization' ) }</label>
 										<Input
+											autoFocus
 											field={ fields.organization }
 											untouch={ untouch }
 											className={ styles.organization }
@@ -293,6 +294,7 @@ class ContactInformation extends React.Component {
 
 									{ this.address2InputIsVisible() && (
 										<Input
+											autoFocus
 											field={ fields.address2 }
 											untouch={ untouch }
 											className={ styles.address2 }


### PR DESCRIPTION
This pull request fixes #796 by updating the `Contact Information` page to set focus on the `Organization` and the second `Address` fields whenever users expand them:

![video](https://cloud.githubusercontent.com/assets/594356/21546591/0918a34a-cde0-11e6-825f-1d27621860d5.gif)


#### Testing instructions

1. Run `git checkout update/contact-information` and start your server, or open a [live branch](https://delphin.live/?branch=update/contact-information)
2. Open the [`Search` page](http://delphin.localhost:1337/search)
3. Select a domain and proceed to the `Contact Information` page
4. Click the `Registering for a company? Add Organization name.` link
5. Check that the `Organization` field that just appeared has focus
6. Click the `Add second line for address.` link
7. Check that the new field that just appeared has focus

#### Additional notes

Funnily I started working with [references](https://facebook.github.io/react/docs/refs-and-the-dom.html) before realizing that there was a much simpler approach :).

#### Reviews

- [x] Code
- [x] Product
 
@Automattic/sdev-feed