### PR TITLE
Make Phone component a text input

### DIFF
--- a/app/components/ui/form/phone/index.js
+++ b/app/components/ui/form/phone/index.js
@@ -47,7 +47,7 @@ class Phone extends React.Component {
 				disabled={ disabled }
 				field={ field }
 				onChange={ this.handleChange }
-				type="tel"
+				type="text"
 				untouch={ untouch }
 				dir="ltr"
 			/>


### PR DESCRIPTION
Fixes https://github.com/Automattic/delphin/issues/1119

This PR simply changes the type of the input used by the Phone component so mobile users are not limited with a number only keyboard and can actually type the `.`.

### Testing Instructions
- Use an iPhone or iPad and navigate to https://delphin.live?branch=fix/ios-tel-input
- Enter the flow and assert that on the contact information page the phone inpout triggers the default keyboard and not the telephone one. As seen on the screenshot below.

![img_2832](https://cloud.githubusercontent.com/assets/230230/21586522/65a95d7e-d115-11e6-85ed-1e1a211adc5c.png)

### Reviews
- [x] Code
- [ ] Product

