### PR TITLE
Checkout: Fix processing state displayed after successful purchase

### DIFF
--- a/app/components/ui/checkout/index.js
+++ b/app/components/ui/checkout/index.js
@@ -31,10 +31,6 @@ class Checkout extends Component {
 		fetchPaygateConfigurationIntervalId = setInterval( this.props.fetchPaygateConfiguration.bind( this ), 10 * 60 * 1000 );
 	}
 
-	componentWillUnmount() {
-		clearInterval( fetchPaygateConfigurationIntervalId );
-	}
-
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.isPurchasing &&
 			! this.props.hasLoadedPaygateConfigurationFromServer &&
@@ -47,7 +43,9 @@ class Checkout extends Component {
 	}
 
 	componentWillUnmount() {
+		this.props.hideProcessingMessage();
 		this.props.resetCheckout();
+		clearInterval( fetchPaygateConfigurationIntervalId );
 	}
 
 	isSubmitButtonDisabled() {
@@ -56,16 +54,16 @@ class Checkout extends Component {
 		return invalid || submitting || isPurchasing;
 	}
 
+	handleClickRedirectToHome( event ) {
+		event.preventDefault();
+
+		this.props.redirect( 'home' );
+	}
+
 	handleClickResetCheckout( event ) {
 		event.preventDefault();
 
 		this.props.resetCheckout();
-	}
-
-	handleClickResetCheckoutAndRedirectToHome( event ) {
-		this.handleClickResetCheckout( event );
-
-		this.props.redirect( 'home' );
 	}
 
 	handleSubmission() {
@@ -79,10 +77,7 @@ class Checkout extends Component {
 	purchaseDomainAndRedirectToSuccess() {
 		this.props.purchaseDomain()
 			.then( () => this.props.redirect( 'success' ) )
-			.catch( () => {
-				this.props.hideProcessingMessage();
-				this.props.redirect( 'checkout' );
-			} );
+			.catch( () => this.props.hideProcessingMessage() );
 	}
 
 	renderCheckoutError() {
@@ -113,7 +108,7 @@ class Checkout extends Component {
 						{ showTryDifferentDomain
 							? i18n.translate( 'You can {{link}}try a different domain{{/link}}.', {
 								components: {
-									link: <a onClick={ this.handleClickResetCheckoutAndRedirectToHome } href="#" />
+									link: <a onClick={ this.handleClickRedirectToHome } href="#" />
 								}
 							} )
 							: i18n.translate( "Don't worry! You can {{link}}try again{{/link}}.", {


### PR DESCRIPTION
Fixes #1117:

> We should fix the `Checkout` page that shows the overlay with the processing state when users want to purchase more than one domain during the same session:
> 
> <img width="301" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/21563256/8ecdee96-ce80-11e6-8695-b80a36f6346b.png">
> 
> This is probably a side effect of https://github.com/Automattic/delphin/pull/1093 as `ui.toggle.isCheckoutProcessing` in the global state tree is never reset.

### Testing
1. Open http://delphin.live:1337 or https://delphin.live/?branch=fix/1117-processing-checkout.
2. Complete the checkout flow, (use an invalid credit card when sandboxed, e.x. 4242424242424241 - incorrect_number error).
3. Click on the get.blog logo and restart the flow with another domain.
4. Make sure payment error information is no longer there.
5. Complete the checkout flow, (use a valid credit card when sandboxed, e.x. 4242424242424242).
6. Click on the get.blog logo and restart the flow with another domain.
7. Make sure processing information is no longer there.

### Review
* [ ] Code
* [ ] Product