### PR TITLE
Hide the menu on click anywhere else on the page

### DIFF
--- a/app/components/ui/header/index.js
+++ b/app/components/ui/header/index.js
@@ -5,6 +5,7 @@ import { bindHandlers } from 'react-bind-handlers';
 import { translate } from 'i18n-calypso';
 import { Link } from 'react-router';
 import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
@@ -13,6 +14,26 @@ import { imageUrl } from 'lib/assets';
 import styles from './styles.scss';
 
 class Header extends Component {
+	componentWillMount() {
+		if ( process.env.BROWSER ) {
+			window.document.addEventListener( 'click', this.handleDocumentClick, false );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( process.env.BROWSER ) {
+			window.document.removeEventListener( 'click', this.handleDocumentClick, false );
+		}
+	}
+
+	handleDocumentClick( event ) {
+		const { hideToggle, isMenuVisible } = this.props;
+
+		if ( isMenuVisible && ! ReactDOM.findDOMNode( this ).contains( event.target ) ) {
+			hideToggle( 'headerMenu' );
+		}
+	}
+
 	handleClickSettingsIcon( event ) {
 		event.preventDefault();
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/delphin/issues/1082

### Testing Instructions
- Load this branch locally or open this link https://delphin.live/?branch=fix/dropdown-menu
- Log in
- Click on the menu
- Click anywhere else on the page
- The menu should close

### Reviews
- [x] Code
- [x] Product