### PR TITLE
Fix log-in header on small screens

### DIFF
--- a/app/components/ui/connect-user/header/styles.scss
+++ b/app/components/ui/connect-user/header/styles.scss
@@ -31,7 +31,6 @@
 
 	@include breakpoint( '<480px' ) {
 		font-size: 2.6rem;
-		margin-top: 0;
 	}
 }
 


### PR DESCRIPTION
Fixes #1088 

This PR remove the `margin-top` redefinition for small viewports which caused the title to overlay the image.

Before | After
------------ | -------------
<img width="418" alt="screen shot 2017-01-04 at 18 17 13" src="https://cloud.githubusercontent.com/assets/230230/21637400/1740d0fe-d2aa-11e6-8bfb-6897f3645660.png"> | <img width="418" alt="screen shot 2017-01-04 at 18 15 23" src="https://cloud.githubusercontent.com/assets/230230/21637405/1ba4f760-d2aa-11e6-9e05-6ba7f1c24aaf.png">



### Testing Instructions
- Load the branch locally or navigate to https://delphin.live/?branch=fix/header-css-mobile
- Go to the log in page
- Reduce the horizontal size of the viewport and assert that the title does not overlay the image anymore

### Reviews
- [x] Code
- [x] Product
