### PR TITLE
Contact Information and Checkout: forms are not cleared on logout

### DIFF
--- a/app/reducers/form/index.js
+++ b/app/reducers/form/index.js
@@ -1,0 +1,9 @@
+// External dependencies
+import { reducer } from 'redux-form';
+
+// Internal dependencies
+import { LOGOUT_USER } from 'reducers/action-types';
+
+export default reducer.plugin( {
+	contactInformation: ( state, { type } ) => ( type === LOGOUT_USER ) ? {} : state,
+} );

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,17 +1,15 @@
-// External dependencies
-import { reducer as form } from 'redux-form';
-
 // Internal dependencies
 import { checkout } from './checkout';
 import { contactInformation } from './contact-information';
 import { contactSupport } from './contact-support';
-import territories from './territories';
+import form from './form';
 import { domainAvailability } from './domain-availability';
 import { domainSuggestions } from './domain-suggestions';
 import nameservers from './nameservers';
 import { notices } from './notices';
 import { prices } from './prices';
 import { service } from './service';
+import territories from './territories';
 import ui from './ui';
 import { user } from './user';
 


### PR DESCRIPTION
Fixes #1128.

## How to reproduce
- Log in to an existing WordPress.com account
- Select a domain and go to the contact information page
- Log out
- Select a domain and go to the contact information page
- See the previous account information are still filled in the form

We would expect those to be cleared on logout. It also applies to the Checkout page.

### Testing
1. Run `git checkout fix/1128-logout-contact-information`, start your server and go to http://delphin.localhost:1337/ or open a [live branch](https://delphin.live/?branch=fix/1128-logout-contact-information).
2. Log in to an existing WordPress.com account.
3. Select a domain and go to the Contact Information page.
4. Go to Checkout page.
5. Log out
6. Select a domain and go to the Contact Information page.
7. Create a new account.
8. Make sure you don't see contact details of the previous user.
9. Fill in the form and go to Checkout page.
10. Make sure you don't see payment details of the previous user.

### Review
* [x] Code
* [x] Product
