### PR TITLE
Analytics: Fix error thrown when Quantcast script has not loaded

### DIFF
--- a/app/lib/analytics/index.js
+++ b/app/lib/analytics/index.js
@@ -394,13 +394,18 @@ const analytics = {
 		// A bug in the Quantcast script causes it to fail silently if
 		// `window.ezt` is populated for the first time after the script is
 		// loaded, so we handle the initial page view when `aquant.js` is
-		// laoded above. In order to prevent duplicate events for the initial
+		// loaded above. In order to prevent duplicate events for the initial
 		// page view, we skip it here.
 		hasSkippedInitialPageView: false,
 
 		recordPageView( urlPath, pageTitle ) {
+			if ( ! isEnabled( 'quantcast' ) ) {
+				return;
+			}
+
 			if ( ! analytics.quantcast.hasSkippedInitialPageView ) {
 				analytics.quantcast.hasSkippedInitialPageView = true;
+
 				return;
 			}
 


### PR DESCRIPTION
This pull request is a follow-up of #1133 that fixes an error thrown when the Quantcast script has not been loaded, something that happens only in development:

<img width="432" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/21713092/7cd15c00-d3f8-11e6-9a7b-d25a0bd142e4.png">

#### Testing instructions

1. Run `git checkout fix/quantcast-tracking` and start your server, or open a [live branch](https://delphin.live/?branch=fix/quantcast-tracking)
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that no error is thrown in your browser's console

#### Reviews

- [ ] Code
- [ ] Product
