### PR TITLE
Remove masking from credit card field on `PaymentFieldArea`

### DIFF
--- a/app/components/ui/checkout/payment-field-area.js
+++ b/app/components/ui/checkout/payment-field-area.js
@@ -4,7 +4,6 @@ import { bindHandlers } from 'react-bind-handlers';
 import i18n from 'i18n-calypso';
 import padStart from 'lodash/padStart';
 import range from 'lodash/range';
-import omit from 'lodash/omit';
 import React, { Component, PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
@@ -19,14 +18,6 @@ import { removeInvalidInputProps } from 'lib/form';
 import ValidationError from 'components/ui/form/validation-error';
 
 class PaymentFieldArea extends Component {
-	handleCreditCardNumberChange( event ) {
-		const { value } = event.target;
-
-		const rawFieldValue = card.parse( value );
-
-		this.props.fields.number.onChange( card.format( rawFieldValue ) );
-	}
-
 	renderCreditCards() {
 		const supportedCards = [
 			'Visa',
@@ -80,9 +71,8 @@ class PaymentFieldArea extends Component {
 
 					<Input
 						type="text"
-						field={ omit( fields.number, 'onChange' ) }
+						field={ fields.number }
 						dir="ltr"
-						onChange={ this.handleCreditCardNumberChange }
 						pattern="[0-9 ]*"
 					/>
 


### PR DESCRIPTION
Fixes #1140.

Per @stephanethomas's recommendation (with which I agree), this commit removes the masking (adding a space after every fourth digit) for the credit card field. This behavior was nice to have, but is likely affecting the conversion rate for some Android users.

@stephanethomas mentioned that he didn't look into delaying the masking with `setTimeout`. I don't think this is worth implementing, as:

- It is a little distracting to have the input behave differently than a normal `<input>`, but I think it is especially distracting if the value of the field changes _after_ I've typed into it.
- Amazon and PayPal (the former of which is notorious for running tons of a/b tests and optimizing UX for anything that pushes the numbers in the right direction) do not implement this behavior on their credit card fields.

**Testing**
- Select a domain and proceed to `Checkout`.
- Enter an invalid credit card number.
- Attempt to submit and assert that there is a validation message preventing the submission.
- Enter `4242424242424242` while store sandboxed.
- Assert that no spaces are added to the input.
- Assert that you can submit the payment successfully.

- [x] Code
- [x] Product