### PR TITLE
Fix: When registering a new domain not able to enter contact info on FF

### DIFF
--- a/app/components/ui/contact-information-form/index.js
+++ b/app/components/ui/contact-information-form/index.js
@@ -83,8 +83,6 @@ class ContactInformationForm extends React.Component {
 		}, {} );
 
 		props.initializeForm( form );
-
-		this.handleFirstNameBlur();
 	}
 
 	setCountryCode( props = this.props ) {
@@ -153,9 +151,7 @@ class ContactInformationForm extends React.Component {
 	handleFirstNameBlur( event ) {
 		this.props.handleStopEditingFirstName();
 
-		if ( event ) {
-			this.props.fields.firstName.onBlur( event.target.value );
-		}
+		this.props.fields.firstName.onBlur( event.target.value );
 	}
 
 	handleFirstNameChange( event ) {


### PR DESCRIPTION
We had `event` undefined in handleFirstNameBlur(), and FF would go nuts about it, while Chrome silently probably fell back to event.

Fixes: https://github.com/Automattic/delphin/issues/1148