### PR TITLE
Tracking: Add Criteo to analytics

### DIFF
--- a/app/actions/analytics.js
+++ b/app/actions/analytics.js
@@ -68,6 +68,9 @@ export const recordGoogleEvent = ( category, action, label, value ) =>
 export const recordTracksEvent = ( name, properties ) =>
 	recordEvent( 'tracks', { name, properties } );
 
+export const recordCriteoSearch = ( domain ) =>
+	recordEvent( 'criteo', { domain } );
+
 export const recordPageView = ( url, title, service ) => ( {
 	type: ANALYTICS_PAGE_VIEW_RECORD,
 	meta: {

--- a/app/components/containers/search.js
+++ b/app/components/containers/search.js
@@ -7,7 +7,7 @@ import { clearDomainSuggestions, fetchDomainSuggestions } from 'actions/domain-s
 import { clearDomainSearch, selectDomain } from 'actions/domain-search';
 import Search from 'components/ui/search';
 import { redirect } from 'actions/routes';
-import { withAnalytics, recordTracksEvent } from 'actions/analytics';
+import { withAnalytics, recordTracksEvent, recordCriteoSearch } from 'actions/analytics';
 
 export default connect(
 	( state, ownProps ) => ( {
@@ -63,7 +63,10 @@ export default connect(
 
 		fetchDomainSuggestions( query ) {
 			withAnalytics(
-				domain => recordTracksEvent( 'delphin_domain_search', { search_string: domain } ),
+				withAnalytics(
+					domain => recordCriteoSearch( domain ),
+					domain => recordTracksEvent( 'delphin_domain_search', { search_string: domain } ),
+				)( query )( dispatch ),
 				fetchDomainSuggestions
 			)( query )( dispatch );
 		},

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -33,6 +33,7 @@ const config = {
 		quantcast: productionOnly,
 		facebookads: productionOnly,
 		atlas: productionOnly,
+		criteo: productionOnly
 	},
 	languages,
 	sift_science_key: productionOnly ? 'a4f69f6759' : 'e00e878351',
@@ -43,6 +44,7 @@ const config = {
 		rest_api_oauth_client_secret: '7FVcj4q9nDvX3ic812oAGDR2oZFjSk0woryR0rRmNIO5Gn7k6HibTIlhvC7Wmof9'
 	},
 	google_analytics_key: 'UA-10673494-28',
+	criteo_account: 35949
 };
 
 if ( typeof window !== 'undefined' && window.location && window.location.search ) {

--- a/client/analytics-middleware/index.js
+++ b/client/analytics-middleware/index.js
@@ -11,7 +11,8 @@ import {
 
 const eventServices = {
 	ga: ( { category, action, label, value } ) => analyticsModule.ga.recordEvent( category, action, label, value ),
-	tracks: ( { name, properties } ) => analyticsModule.tracks.recordEvent( name, properties )
+	tracks: ( { name, properties } ) => analyticsModule.tracks.recordEvent( name, properties ),
+	criteo: ( { domain } ) => analyticsModule.criteo.recordSearch( domain )
 };
 
 const pageViewServices = {


### PR DESCRIPTION
Implement page and purchase tracking for Criteo

#### Test
- Set `features.ad_tracking` and `features.criteo` to `true` (https://github.com/Automattic/delphin/blob/master/app/config/index.js)
- Make sure you see events being sent to Criteo for these pages: `/, verify, contact-information, signup, checkout`
- Make sure the events are sent for every `search` with the `search term` being passed to the event
- Make sure an event is sent for a successful purchase

#### Reviews
 
- [x] Code
- [x] Product