### PR TITLE
Analytics: Fix parameter name for Criteo

### DIFF
--- a/app/lib/analytics/index.js
+++ b/app/lib/analytics/index.js
@@ -519,7 +519,7 @@ const analytics = {
 
 			return [
 				{ event: 'setAccount', account: config( 'criteo_account' ) },
-				{ event: 'setSiteType', account: deviceType },
+				{ event: 'setSiteType', type: deviceType },
 				{ event: 'setEmail', email: [ '' ] }
 			];
 		},


### PR DESCRIPTION
Change account to type, as it wasn't passing the device type, but sending two accounts.

We're passing `deviceType` as `account` instead of `type`:
```
a:35949
v:4.1.0
p0:e=exd&a=d&site_type=d
p1:e=ce&m=%5B%5D
p2:e=vh
p3:e=dis&a=[35949,d]
adce:1
```
![criteo-account-d](https://cloud.githubusercontent.com/assets/1103398/22302007/58024fe4-e32d-11e6-9d38-ac3f9f99f4f5.png)

It should be:
```
a:35949
v:4.1.0
p0:e=exd&site_type=d
p1:e=ce&m=%5B%5D
p2:e=vh
p3:e=dis
adce:1
```