### PR TITLE
Mobile: Do not auto-focus if viewport is mobile breakpoint size

### DIFF
--- a/app/components/ui/form/input.js
+++ b/app/components/ui/form/input.js
@@ -6,6 +6,7 @@ import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
+import { isMobile } from 'lib/viewport';
 import { removeInvalidInputProps } from 'lib/form';
 import styles from './styles.scss';
 import { withErrorFocusable } from 'components/ui/form/error-focuser';
@@ -53,7 +54,14 @@ class Input extends React.Component {
 				[ styles.hasError ]: isInvalid,
 				[ styles.errorLtr ]: this.props.dir === 'ltr'
 			} ),
-			newProps = omit( this.props, [ 'className', 'field', 'untouch', 'gridIconSize', 'inputClassName' ] );
+			newProps = omit( this.props, [
+				'autoFocus',
+				'className',
+				'field',
+				'untouch',
+				'gridIconSize',
+				'inputClassName'
+			] );
 
 		return (
 			<div className={ className }>
@@ -63,6 +71,7 @@ class Input extends React.Component {
 					</span>
 				) }
 				<input
+					autoFocus={ ! isMobile() && this.props.autoFocus }
 					id={ field.name }
 					className={ inputClassName }
 					{ ...removeInvalidInputProps( field ) }
@@ -84,6 +93,7 @@ class Input extends React.Component {
 }
 
 Input.propTypes = {
+	autoFocus: PropTypes.bool,
 	className: PropTypes.string,
 	dir: PropTypes.string,
 	field: PropTypes.object.isRequired,

--- a/app/components/ui/search-input/index.js
+++ b/app/components/ui/search-input/index.js
@@ -5,6 +5,7 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import { bindHandlers } from 'react-bind-handlers';
 
 // Internal dependencies
+import { isMobile } from 'lib/viewport';
 import styles from './styles.scss';
 import KeywordsContainer from 'components/containers/keywords';
 
@@ -46,7 +47,7 @@ class SearchInput extends React.Component {
 				<input
 					autoCapitalize="off"
 					autoComplete="off"
-					autoFocus
+					autoFocus={ ! isMobile() }
 					ref="searchInput"
 					type="text"
 					className="search"

--- a/app/lib/viewport/index.js
+++ b/app/lib/viewport/index.js
@@ -1,0 +1,9 @@
+/**
+ * Determine whether a user is viewing Delphin from a device within a
+ * particular mobile-first responsive breakpoint
+ *
+ * @returns {boolean} Whether the viewport is mobile breakpoint size
+ */
+export const isMobile = () => (
+	global.window ? Math.min( global.window.innerWidth, global.window.innerHeight ) <= 480 : false
+);


### PR DESCRIPTION
Auto focusing inputs on mobile can be a hassle as the keyboard appears and pushes all elements or it's hard to see what's on screen.

If viewport is <= 480px, do not auto focus. This is the same strategy used [in Calypso](https://github.com/Automattic/wp-calypso/blob/8e977e9b986fde76012a4885c0cab0e7831b5a8c/client/post-editor/editor-title/index.jsx#L110).

**Testing**
*In a viewport > 480px in width and height*
- Visit `/log-in` and assert that the field is auto-focused.
- Visit `/search?q=test` and assert that the field is auto-focused

*In a viewport <= 480px in width or height*
- Visit `/log-in` and assert that the field is not auto-focused.
- Visit `/search?q=test` and assert that the field is not auto-focused

--------------
- [x] Code
- [x] Product