### PR TITLE
Inform about the migration to WordPress.com

### DIFF
--- a/app/components/ui/connect-user/header/index.js
+++ b/app/components/ui/connect-user/header/index.js
@@ -12,7 +12,7 @@ const Header = ( { intention } ) => {
 	let text = '';
 
 	if ( intention === 'signup' || intention === 'login' ) {
-		heading = i18n.translate( 'We\'re making some changes' );
+		heading = i18n.translate( 'Get.blog has moved to WordPress.com' );
 	} else if ( intention === 'verifyUser' ) {
 		heading = i18n.translate( 'Check your email' );
 

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -143,12 +143,10 @@ const ConnectUser = React.createClass( {
 							<div>
 								<fieldset>
 									<label className={ styles.emailLabel }>
-										{ i18n.translate( 'We have merged the ease of use of get.blog with the power of WordPress.com. ' +
-											'Get.blog domains are now managed at WordPress.com.'
-										) }
+										{ i18n.translate( 'We have merged the ease of use of get.blog with the power of WordPress.com. ' ) }
 									</label>
 									<label>
-										{ i18n.translate( 'If you purchased a domain on get.blog, ' +
+										{ i18n.translate( 'Get.blog domains are now managed at WordPress.com. If you purchased a domain on get.blog, ' +
 											'we sent you an email with instructions to log in and manage your domains on WordPress.com. ' +
 											'Check your email for more information or ' +
 											'visit WordPress.com now to {{link}}create your password{{/link}}.', {

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -120,7 +120,7 @@ const ConnectUser = React.createClass( {
 			<Form.Footer>
 				<p>
 					{ i18n.translate(
-						'For any questions, please contact us at {{link}}help@get.blog{{/link}}.',
+						'For any questions, please contact us at {{link}}help@wordpress.com{{/link}}.',
 						{
 							components: { link: <a href={ config( 'support_link' ) } rel="noopener noreferrer" /> }
 						}
@@ -143,13 +143,17 @@ const ConnectUser = React.createClass( {
 							<div>
 								<fieldset>
 									<label className={ styles.emailLabel }>
-										{ i18n.translate( 'Get.blog is not available right now while we make some important changes.'
+										{ i18n.translate( 'We have merged the ease of use of get.blog with the power of WordPress.com. ' +
+											'Get.blog domains are now managed at WordPress.com.'
 										) }
 									</label>
 									<label>
 										{ i18n.translate( 'If you purchased a domain on get.blog, ' +
-											'we\'ll send you an email with instructions ' +
-											'to log in and manage your domains.'
+											'we sent you an email with instructions to log in and manage your domains on WordPress.com. ' +
+											'Check your email for more information or ' +
+											'visit WordPress.com now to {{link}}create your password{{/link}}.', {
+											components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword" rel="noopener noreferrer" /> }
+										}
 										) }
 									</label>
 								</fieldset>

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -152,8 +152,8 @@ const ConnectUser = React.createClass( {
 											'we sent you an email with instructions to log in and manage your domains on WordPress.com. ' +
 											'Check your email for more information or ' +
 											'visit WordPress.com now to {{link}}create your password{{/link}}.', {
-											components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword" rel="noopener noreferrer" /> }
-										}
+												components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword" rel="noopener noreferrer" /> }
+											}
 										) }
 									</label>
 								</fieldset>

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -143,14 +143,13 @@ const ConnectUser = React.createClass( {
 							<div>
 								<fieldset>
 									<label className={ styles.emailLabel }>
-										{ i18n.translate( 'We have merged the ease of use of get.blog with the power of WordPress.com. ' ) }
+										{ i18n.translate( 'Enjoy the ease of use of get.blog, now with the power of WordPress.com.' ) }
 									</label>
 									<label>
 										{ i18n.translate( 'Get.blog domains are now managed at WordPress.com. If you purchased a domain on get.blog, ' +
-											'we sent you an email with instructions to log in and manage your domains on WordPress.com. ' +
-											'Check your email for more information or ' +
-											'visit WordPress.com now to {{link}}create your password{{/link}}.', {
-												components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword" rel="noopener noreferrer" /> }
+											'you can log in to WordPress.com using the same email address. ' +
+											'If you don\'t have a password,  {{link}}create your password{{/link}}.', {
+												components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword&source=gdb" rel="noopener noreferrer" /> }
 											}
 										) }
 									</label>

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -148,7 +148,7 @@ const ConnectUser = React.createClass( {
 									<label>
 										{ i18n.translate( 'Get.blog domains are now managed at WordPress.com. If you purchased a domain on get.blog, ' +
 											'you can log in to WordPress.com using the same email address. ' +
-											'If you don\'t have a password,  {{link}}create your password{{/link}}.', {
+											'If you don\'t have a password, {{link}}create your password{{/link}}.', {
 												components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword&source=gdb" rel="noopener noreferrer" /> }
 											}
 										) }

--- a/app/components/ui/connect-user/index.js
+++ b/app/components/ui/connect-user/index.js
@@ -146,7 +146,7 @@ const ConnectUser = React.createClass( {
 										{ i18n.translate( 'Enjoy the ease of use of get.blog, now with the power of WordPress.com.' ) }
 									</label>
 									<label>
-										{ i18n.translate( 'Get.blog domains are now managed at WordPress.com. If you purchased a domain on get.blog, ' +
+										{ i18n.translate( 'If you purchased a domain on get.blog, ' +
 											'you can log in to WordPress.com using the same email address. ' +
 											'If you don\'t have a password, {{link}}create your password{{/link}}.', {
 												components: { link: <a href="https://wordpress.com/wp-login.php?action=lostpassword&source=gdb" rel="noopener noreferrer" /> }

--- a/app/components/ui/learn-more/index.js
+++ b/app/components/ui/learn-more/index.js
@@ -40,6 +40,15 @@ class LearnMore extends React.Component {
 		} );
 	}
 
+	componentWillMount() {
+		// No search for you!
+		// (we're sunsetting delphin, sorry)
+		if ( typeof window !== 'undefined' ) {
+			window.location.replace( 'https://support.wordpress.com' );
+			return;
+		}
+	}
+
 	componentDidMount() {
 		const {
 			hasLoadedPricesFromServer,

--- a/app/components/ui/menu/index.js
+++ b/app/components/ui/menu/index.js
@@ -4,7 +4,6 @@ import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 
 // Internal dependencies
-import { getPath } from 'routes';
 import styles from './styles.scss';
 import Link from './link';
 import SessionLinks from 'components/containers/session-links';
@@ -14,7 +13,7 @@ const Menu = ( { location } ) => {
 		<menu className={ styles.menu }>
 			<SessionLinks location={ location } />
 
-			<Link to={ getPath( 'learnMore' ) }>
+			<Link to="https://support.wordpress.com/">
 				{ i18n.translate( 'Support' ) }
 			</Link>
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -37,7 +37,7 @@ const config = {
 	},
 	languages,
 	sift_science_key: productionOnly ? 'a4f69f6759' : 'e00e878351',
-	support_link: 'mailto:help@get.blog',
+	support_link: 'mailto:help@wordpress.com',
 	tracks_event_prefix: 'delphin_',
 	wordpress: {
 		rest_api_oauth_client_id: 46199,


### PR DESCRIPTION
After the migration is over, we need to update the copy on the login page, as noted in #1171.
Additionally, the `Support` link in the footer menu will redirect to `support.wordpress.com`, since that's were the users should seek support now.

![delphin localhost_1337_log-in 1](https://user-images.githubusercontent.com/3392497/29873124-82274594-8d92-11e7-8e23-f6b1e74125a8.png)

Fixes #1171