### PR TITLE
Disable Sentry.io integration

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -26,7 +26,7 @@ const config = {
 		boom_analytics: productionOnly,
 		google_analytics: productionOnly,
 		mc_analytics: productionOnly,
-		sentry: productionOnly,
+		sentry: false,
 		tracks: productionOnly,
 		googleads: productionOnly,
 		bingads: productionOnly,


### PR DESCRIPTION
No need to monitor the app anymore, we should remove this integration.